### PR TITLE
Add navigation bar with back button to subpages

### DIFF
--- a/gta/index.html
+++ b/gta/index.html
@@ -7,7 +7,10 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700;900&display=swap" rel="stylesheet">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: system-ui, sans-serif; background: #0a0a0a; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+    body { font-family: system-ui, sans-serif; background: #0a0a0a; display: flex; justify-content: center; align-items: center; min-height: 100vh; padding-top: 48px; }
+    .va-topbar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: linear-gradient(135deg, #3498db, #2c3e50); display: flex; align-items: center; padding: 0 1rem; z-index: 9999; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
+    .va-topbar a { color: #fff; text-decoration: none; font-family: 'Segoe UI', system-ui, sans-serif; font-size: 0.95rem; font-weight: bold; display: flex; align-items: center; gap: 0.5rem; transition: opacity 0.2s; }
+    .va-topbar a:hover { opacity: 0.85; }
     #game { width: 480px; height: 640px; }
     .gta-game {
       display: flex; flex-direction: column; align-items: center;
@@ -150,6 +153,12 @@
   </style>
 </head>
 <body>
+  <nav class="va-topbar">
+    <a href="../">
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+      Vibecoding Academy
+    </a>
+  </nav>
   <div id="game"></div>
   <script>
 (function() {

--- a/pong/index.html
+++ b/pong/index.html
@@ -6,7 +6,10 @@
   <title>Pong</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: system-ui, sans-serif; background: #111; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+    body { font-family: system-ui, sans-serif; background: #111; display: flex; justify-content: center; align-items: center; min-height: 100vh; padding-top: 48px; }
+    .va-topbar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: linear-gradient(135deg, #3498db, #2c3e50); display: flex; align-items: center; padding: 0 1rem; z-index: 9999; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
+    .va-topbar a { color: #fff; text-decoration: none; font-family: 'Segoe UI', system-ui, sans-serif; font-size: 0.95rem; font-weight: bold; display: flex; align-items: center; gap: 0.5rem; transition: opacity 0.2s; }
+    .va-topbar a:hover { opacity: 0.85; }
     #game { width: 420px; height: 500px; position: relative; }
     .pong-wrap { display:flex; flex-direction:column; align-items:center; height:100%; background:#111; padding:8px; box-sizing:border-box; }
     .pong-scores { display:flex; justify-content:space-between; width:300px; color:#fff; font:bold 14px/1 system-ui; padding:4px 0 6px; }
@@ -19,6 +22,12 @@
   </style>
 </head>
 <body>
+  <nav class="va-topbar">
+    <a href="../">
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
+      Vibecoding Academy
+    </a>
+  </nav>
   <div id="game"></div>
   <script>
 (function() {


### PR DESCRIPTION
## Summary
- Adds a sticky navigation bar to both game subpages (Pong, GTA) matching the homepage gradient style
- Navigation bar includes a back-arrow and "Vibecoding Academy" link to return to the homepage
- Body padding adjusted so game content doesn't overlap with the navbar

## Test plan
- [ ] Open pong/index.html → Navbar visible at top with back button → click leads to homepage
- [ ] Open gta/index.html → Navbar visible at top with back button → click leads to homepage
- [ ] Games still render and play correctly without overlap
- [ ] Works on mobile and desktop viewports

https://claude.ai/code/session_01Hi5XnaTSwpv5Gw2qubaPTF