### PR TITLE
Add robots.txt to block search engines and AI crawlers

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,52 @@
+# Block all search engines and AI crawlers
+User-agent: *
+Disallow: /
+
+# Explicitly block known AI crawlers
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: YouBot
+Disallow: /


### PR DESCRIPTION
## Summary
- Adds a `robots.txt` that blocks all bots via `User-agent: * / Disallow: /`
- Explicitly blocks known AI crawlers: GPTBot, ChatGPT-User, ClaudeBot, Google-Extended, CCBot, Bytespider, PerplexityBot, Applebot-Extended, cohere-ai, FacebookBot, Meta-ExternalAgent, Amazonbot, YouBot, and others

## Test plan
- [ ] Verify `robots.txt` is served at the site root
- [ ] Validate syntax with a robots.txt checker (e.g. https://technicalseo.com/tools/robots-txt/)

https://claude.ai/code/session_01EzEEy4nLn3rHksFk4gT51i