### PR TITLE
Fix spelling: Gran → Grand Thomas Auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Fertige Projekte aus dem Workshop:
 | Projekt | Beschreibung |
 |---------|-------------|
 | [Pong](https://fauteck.github.io/vibecoding-academy/pong/) | Klassisches Pong-Spiel: Spieler gegen KI |
-| [Gran Thomas Auto 6](https://fauteck.github.io/vibecoding-academy/gta/) | GTA-Parodie im RTL-Sendezentrum |
+| [Grand Thomas Auto 6](https://fauteck.github.io/vibecoding-academy/gta/) | GTA-Parodie im RTL-Sendezentrum |
 
 ## Ideen & Konzepte
 

--- a/gta/gta.md
+++ b/gta/gta.md
@@ -1,4 +1,4 @@
-# Gran Thomas Auto 6
+# Grand Thomas Auto 6
 
 ## Beschreibung
 Eine epische GTA-Parodie. Das Spiel startet mit einem absurd uebertriebenem Fake-AAA-Intro im Stil von GTA6 - dramatische Texte, Fake-Ladebalken, cinematische Effekte. Nach dem Intro-Schock wechselt das Spiel in eine GTA1-artige 2D-Draufsicht: Thomas, der Hauptdarsteller, laeuft durch das RTL-Sendezentrum in Koeln. Statt zu schiessen, trinkt er ueberall Kaffee auf Knopfdruck. RTL-Logos und TV-Mitarbeiter ueberall. Willkommen im Sendezentrum.
@@ -559,7 +559,7 @@ Eine epische GTA-Parodie. Das Spiel startet mit einem absurd uebertriebenem Fake
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Gran Thomas Auto 6</title>
+  <title>Grand Thomas Auto 6</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700;900&display=swap" rel="stylesheet">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/gta/index.html
+++ b/gta/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Gran Thomas Auto 6</title>
+  <title>Grand Thomas Auto 6</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700;900&display=swap" rel="stylesheet">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.html
+++ b/index.html
@@ -439,7 +439,7 @@
         <a class="card text-decoration-none h-100" href="./gta/">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">🚗</div>
-            <h6 class="card-title">Gran Thomas Auto 6</h6>
+            <h6 class="card-title">Grand Thomas Auto 6</h6>
             <p class="card-text text-muted small">GTA-Parodie im RTL-Sendezentrum</p>
           </div>
         </a>


### PR DESCRIPTION
## Summary
- Korrigiert den Tippfehler "Gran Thomas Auto" → "Grand Thomas Auto" in allen 4 betroffenen Dateien (`index.html`, `README.md`, `gta/gta.md`, `gta/index.html`)

## Test plan
- [ ] Prüfen, dass "Grand Thomas Auto" korrekt auf der Hauptseite angezeigt wird
- [ ] Prüfen, dass der GTA-Spieltitel korrekt ist

https://claude.ai/code/session_01Rid1QJzs5urVL1f9iTgwuh