### PR TITLE
Add consistent navigation to all subpages

### DIFF
--- a/gta/index.html
+++ b/gta/index.html
@@ -5,12 +5,77 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <title>Grand Thomas Auto 6</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
+        crossorigin="anonymous" referrerpolicy="no-referrer">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: system-ui, sans-serif; background: #0a0a0a; display: flex; justify-content: center; align-items: flex-start; min-height: 100vh; padding-top: 48px; overflow: hidden; }
-    .va-topbar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: linear-gradient(135deg, #3498db, #2c3e50); display: flex; align-items: center; padding: 0 1rem; z-index: 9999; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
-    .va-topbar a { color: #fff; text-decoration: none; font-family: 'Segoe UI', system-ui, sans-serif; font-size: 0.95rem; font-weight: bold; display: flex; align-items: center; gap: 0.5rem; transition: opacity 0.2s; }
-    .va-topbar a:hover { opacity: 0.85; }
+
+    /* ── Desktop Navbar (>992px) ─────────────────────── */
+    .site-navbar {
+      display: none; position: fixed; top: 0; left: 0; right: 0;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      z-index: 1030; box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      align-items: center; justify-content: space-between;
+      padding: 0.5rem 1.5rem;
+    }
+    .site-navbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.3rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .site-navbar-links { display: flex; align-items: center; gap: 0.25rem; }
+    .site-navbar-link {
+      color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
+      padding: 0.4rem 0.8rem; border-radius: 6px; transition: background 0.2s, color 0.2s;
+    }
+    .site-navbar-link:hover, .site-navbar-link.active {
+      color: #fff; background: rgba(255,255,255,0.15);
+    }
+
+    /* ── Mobile Top Bar (<=992px) ──��─────────────────── */
+    .mobile-topbar {
+      position: fixed; top: 0; left: 0; right: 0; height: 56px;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 1rem; z-index: 1030;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .mobile-topbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.1rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .mobile-topbar-btn {
+      color: rgba(255,255,255,0.85); text-decoration: none; font-size: 1.1rem;
+      padding: 0.4rem; transition: color 0.2s;
+    }
+    .mobile-topbar-btn:hover { color: #fff; }
+
+    /* ── Mobile Bottom Nav (<=992px) ─────────────────── */
+    .bottom-nav {
+      position: fixed; bottom: 0; left: 0; right: 0; height: 60px;
+      background: #2c3e50; display: flex; justify-content: space-around; align-items: center;
+      z-index: 1030; box-shadow: 0 -2px 8px rgba(0,0,0,0.15);
+    }
+    .bottom-nav-item {
+      display: flex; flex-direction: column; align-items: center; gap: 0.15rem;
+      color: rgba(255,255,255,0.5); text-decoration: none; font-size: 0.65rem;
+      padding: 0.3rem 0.6rem; transition: color 0.2s;
+    }
+    .bottom-nav-item i { font-size: 1.15rem; }
+    .bottom-nav-item:hover, .bottom-nav-item.active { color: #fff; }
+    .bottom-nav-item.active i { color: #3498db; }
+
+    /* ── Responsive ──────────────────────────────────── */
+    @media (min-width: 992px) {
+      .site-navbar { display: flex; }
+      .mobile-topbar, .bottom-nav { display: none !important; }
+    }
+    @media (max-width: 991.98px) {
+      body { padding-top: 56px; padding-bottom: 60px; }
+      .gta-controls { bottom: 80px; }
+    }
+
     #game { width: 100vw; height: calc(100vh - 48px); display: flex; align-items: center; justify-content: center; }
     .gta-game {
       display: flex; flex-direction: column; align-items: center; justify-content: center;
@@ -166,12 +231,53 @@
   </style>
 </head>
 <body>
-  <nav class="va-topbar">
-    <a href="../">
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-      Vibecoding Academy
+  <!-- Desktop Navbar (>992px) -->
+  <nav class="site-navbar">
+    <a class="site-navbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <div class="site-navbar-links">
+      <a class="site-navbar-link" href="../">Home</a>
+      <a class="site-navbar-link" href="../pong/">Pong</a>
+      <a class="site-navbar-link active" href="../gta/">GTA</a>
+      <a class="site-navbar-link" href="../handout/">Handout</a>
+      <a class="site-navbar-link" href="https://github.com/Fauteck/vibecoding-academy" target="_blank" rel="noopener">
+        <i class="fab fa-github"></i> GitHub
+      </a>
+    </div>
+  </nav>
+
+  <!-- Mobile Top Bar (<=992px) -->
+  <div class="mobile-topbar">
+    <a class="mobile-topbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <a href="https://github.com/Fauteck/vibecoding-academy"
+       class="mobile-topbar-btn" target="_blank" rel="noopener" aria-label="GitHub">
+      <i class="fab fa-github"></i>
+    </a>
+  </div>
+
+  <!-- Mobile Bottom Navigation (<=992px) -->
+  <nav class="bottom-nav">
+    <a class="bottom-nav-item" href="../">
+      <i class="fas fa-home"></i>
+      <span>Home</span>
+    </a>
+    <a class="bottom-nav-item" href="../pong/">
+      <i class="fas fa-table-tennis-paddle-ball"></i>
+      <span>Pong</span>
+    </a>
+    <a class="bottom-nav-item active" href="../gta/">
+      <i class="fas fa-car"></i>
+      <span>GTA</span>
+    </a>
+    <a class="bottom-nav-item" href="../handout/">
+      <i class="fas fa-file-alt"></i>
+      <span>Handout</span>
     </a>
   </nav>
+
   <div id="game"></div>
   <script>
 (function() {

--- a/handout/index.html
+++ b/handout/index.html
@@ -5,12 +5,76 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Handout: Vibecoding &amp; Hosting - Vibecoding Academy</title>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💻</text></svg>">
+  <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
+        crossorigin="anonymous" referrerpolicy="no-referrer">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: 'Segoe UI', system-ui, -apple-system, sans-serif; background: #f5f7fa; padding-top: 48px; color: #222; }
-    .va-topbar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: linear-gradient(135deg, #3498db, #2c3e50); display: flex; align-items: center; padding: 0 1rem; z-index: 9999; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
-    .va-topbar a { color: #fff; text-decoration: none; font-family: 'Segoe UI', system-ui, sans-serif; font-size: 0.95rem; font-weight: bold; display: flex; align-items: center; gap: 0.5rem; transition: opacity 0.2s; }
-    .va-topbar a:hover { opacity: 0.85; }
+    body { font-family: 'Segoe UI', system-ui, -apple-system, sans-serif; background: #f5f7fa; color: #222; }
+
+    /* ── Desktop Navbar (>992px) ─────────────────────── */
+    .site-navbar {
+      display: none;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      position: sticky; top: 0; z-index: 1030;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      align-items: center; justify-content: space-between;
+      padding: 0.5rem 1.5rem;
+    }
+    .site-navbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.3rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .site-navbar-links { display: flex; align-items: center; gap: 0.25rem; }
+    .site-navbar-link {
+      color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
+      padding: 0.4rem 0.8rem; border-radius: 6px; transition: background 0.2s, color 0.2s;
+    }
+    .site-navbar-link:hover, .site-navbar-link.active {
+      color: #fff; background: rgba(255,255,255,0.15);
+    }
+
+    /* ── Mobile Top Bar (<=992px) ────────────────────── */
+    .mobile-topbar {
+      position: fixed; top: 0; left: 0; right: 0; height: 56px;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 1rem; z-index: 1030;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .mobile-topbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.1rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .mobile-topbar-btn {
+      color: rgba(255,255,255,0.85); text-decoration: none; font-size: 1.1rem;
+      padding: 0.4rem; transition: color 0.2s;
+    }
+    .mobile-topbar-btn:hover { color: #fff; }
+
+    /* ── Mobile Bottom Nav (<=992px) ─────────────────── */
+    .bottom-nav {
+      position: fixed; bottom: 0; left: 0; right: 0; height: 60px;
+      background: #2c3e50; display: flex; justify-content: space-around; align-items: center;
+      z-index: 1030; box-shadow: 0 -2px 8px rgba(0,0,0,0.15);
+    }
+    .bottom-nav-item {
+      display: flex; flex-direction: column; align-items: center; gap: 0.15rem;
+      color: rgba(255,255,255,0.5); text-decoration: none; font-size: 0.65rem;
+      padding: 0.3rem 0.6rem; transition: color 0.2s;
+    }
+    .bottom-nav-item i { font-size: 1.15rem; }
+    .bottom-nav-item:hover, .bottom-nav-item.active { color: #fff; }
+    .bottom-nav-item.active i { color: #3498db; }
+
+    /* ── Responsive ──────────────────────────────────── */
+    @media (min-width: 992px) {
+      .site-navbar { display: flex; }
+      .mobile-topbar, .bottom-nav { display: none !important; }
+    }
+    @media (max-width: 991.98px) {
+      body { padding-top: 56px; padding-bottom: 60px; }
+    }
     #content { max-width: 800px; margin: 2rem auto; padding: 2rem; background: #fff; border-radius: 8px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); line-height: 1.7; }
     #content h1 { font-size: 1.8rem; margin-bottom: 0.5rem; color: #2c3e50; border-bottom: 2px solid #eee; padding-bottom: 0.5rem; }
     #content .subtitle { color: #666; margin-bottom: 1.5rem; font-size: 1rem; }
@@ -46,18 +110,58 @@
       #content { margin: 1rem; padding: 1.2rem; }
     }
     @media print {
-      .va-topbar { display: none; }
-      body { padding-top: 0; background: #fff; }
+      .site-navbar, .mobile-topbar, .bottom-nav { display: none !important; }
+      body { padding-top: 0; padding-bottom: 0; background: #fff; }
       #content { box-shadow: none; margin: 0; padding: 1rem; max-width: 100%; }
       .back-link { display: none; }
     }
   </style>
 </head>
 <body>
-  <nav class="va-topbar">
-    <a href="../">
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-      Vibecoding Academy
+  <!-- Desktop Navbar (>992px) -->
+  <nav class="site-navbar">
+    <a class="site-navbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <div class="site-navbar-links">
+      <a class="site-navbar-link" href="../">Home</a>
+      <a class="site-navbar-link" href="../pong/">Pong</a>
+      <a class="site-navbar-link" href="../gta/">GTA</a>
+      <a class="site-navbar-link active" href="../handout/">Handout</a>
+      <a class="site-navbar-link" href="https://github.com/Fauteck/vibecoding-academy" target="_blank" rel="noopener">
+        <i class="fab fa-github"></i> GitHub
+      </a>
+    </div>
+  </nav>
+
+  <!-- Mobile Top Bar (<=992px) -->
+  <div class="mobile-topbar">
+    <a class="mobile-topbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <a href="https://github.com/Fauteck/vibecoding-academy"
+       class="mobile-topbar-btn" target="_blank" rel="noopener" aria-label="GitHub">
+      <i class="fab fa-github"></i>
+    </a>
+  </div>
+
+  <!-- Mobile Bottom Navigation (<=992px) -->
+  <nav class="bottom-nav">
+    <a class="bottom-nav-item" href="../">
+      <i class="fas fa-home"></i>
+      <span>Home</span>
+    </a>
+    <a class="bottom-nav-item" href="../pong/">
+      <i class="fas fa-table-tennis-paddle-ball"></i>
+      <span>Pong</span>
+    </a>
+    <a class="bottom-nav-item" href="../gta/">
+      <i class="fas fa-car"></i>
+      <span>GTA</span>
+    </a>
+    <a class="bottom-nav-item active" href="../handout/">
+      <i class="fas fa-file-alt"></i>
+      <span>Handout</span>
     </a>
   </nav>
 

--- a/ideen/viewer.html
+++ b/ideen/viewer.html
@@ -4,12 +4,76 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Idee - Vibecoding Academy</title>
+  <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
+        crossorigin="anonymous" referrerpolicy="no-referrer">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: 'Segoe UI', system-ui, -apple-system, sans-serif; background: #f5f7fa; padding-top: 48px; color: #222; }
-    .va-topbar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: linear-gradient(135deg, #3498db, #2c3e50); display: flex; align-items: center; padding: 0 1rem; z-index: 9999; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
-    .va-topbar a { color: #fff; text-decoration: none; font-family: 'Segoe UI', system-ui, sans-serif; font-size: 0.95rem; font-weight: bold; display: flex; align-items: center; gap: 0.5rem; transition: opacity 0.2s; }
-    .va-topbar a:hover { opacity: 0.85; }
+    body { font-family: 'Segoe UI', system-ui, -apple-system, sans-serif; background: #f5f7fa; color: #222; }
+
+    /* ── Desktop Navbar (>992px) ─────────────────────── */
+    .site-navbar {
+      display: none;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      position: sticky; top: 0; z-index: 1030;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      align-items: center; justify-content: space-between;
+      padding: 0.5rem 1.5rem;
+    }
+    .site-navbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.3rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .site-navbar-links { display: flex; align-items: center; gap: 0.25rem; }
+    .site-navbar-link {
+      color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
+      padding: 0.4rem 0.8rem; border-radius: 6px; transition: background 0.2s, color 0.2s;
+    }
+    .site-navbar-link:hover, .site-navbar-link.active {
+      color: #fff; background: rgba(255,255,255,0.15);
+    }
+
+    /* ── Mobile Top Bar (<=992px) ────────────────────── */
+    .mobile-topbar {
+      position: fixed; top: 0; left: 0; right: 0; height: 56px;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 1rem; z-index: 1030;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .mobile-topbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.1rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .mobile-topbar-btn {
+      color: rgba(255,255,255,0.85); text-decoration: none; font-size: 1.1rem;
+      padding: 0.4rem; transition: color 0.2s;
+    }
+    .mobile-topbar-btn:hover { color: #fff; }
+
+    /* ── Mobile Bottom Nav (<=992px) ─────────────────── */
+    .bottom-nav {
+      position: fixed; bottom: 0; left: 0; right: 0; height: 60px;
+      background: #2c3e50; display: flex; justify-content: space-around; align-items: center;
+      z-index: 1030; box-shadow: 0 -2px 8px rgba(0,0,0,0.15);
+    }
+    .bottom-nav-item {
+      display: flex; flex-direction: column; align-items: center; gap: 0.15rem;
+      color: rgba(255,255,255,0.5); text-decoration: none; font-size: 0.65rem;
+      padding: 0.3rem 0.6rem; transition: color 0.2s;
+    }
+    .bottom-nav-item i { font-size: 1.15rem; }
+    .bottom-nav-item:hover, .bottom-nav-item.active { color: #fff; }
+    .bottom-nav-item.active i { color: #3498db; }
+
+    /* ── Responsive ──────────────────────────────────── */
+    @media (min-width: 992px) {
+      .site-navbar { display: flex; }
+      .mobile-topbar, .bottom-nav { display: none !important; }
+    }
+    @media (max-width: 991.98px) {
+      body { padding-top: 56px; padding-bottom: 60px; }
+    }
     #content { max-width: 800px; margin: 2rem auto; padding: 2rem; background: #fff; border-radius: 8px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); line-height: 1.7; }
     #content h1 { font-size: 1.8rem; margin-bottom: 1rem; color: #2c3e50; border-bottom: 2px solid #eee; padding-bottom: 0.5rem; }
     #content h2 { font-size: 1.4rem; margin-top: 1.8rem; margin-bottom: 0.6rem; color: #34495e; }
@@ -39,10 +103,50 @@
   </style>
 </head>
 <body>
-  <nav class="va-topbar">
-    <a href="../">
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-      Vibecoding Academy
+  <!-- Desktop Navbar (>992px) -->
+  <nav class="site-navbar">
+    <a class="site-navbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <div class="site-navbar-links">
+      <a class="site-navbar-link active" href="../">Home</a>
+      <a class="site-navbar-link" href="../pong/">Pong</a>
+      <a class="site-navbar-link" href="../gta/">GTA</a>
+      <a class="site-navbar-link" href="../handout/">Handout</a>
+      <a class="site-navbar-link" href="https://github.com/Fauteck/vibecoding-academy" target="_blank" rel="noopener">
+        <i class="fab fa-github"></i> GitHub
+      </a>
+    </div>
+  </nav>
+
+  <!-- Mobile Top Bar (<=992px) -->
+  <div class="mobile-topbar">
+    <a class="mobile-topbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <a href="https://github.com/Fauteck/vibecoding-academy"
+       class="mobile-topbar-btn" target="_blank" rel="noopener" aria-label="GitHub">
+      <i class="fab fa-github"></i>
+    </a>
+  </div>
+
+  <!-- Mobile Bottom Navigation (<=992px) -->
+  <nav class="bottom-nav">
+    <a class="bottom-nav-item active" href="../">
+      <i class="fas fa-home"></i>
+      <span>Home</span>
+    </a>
+    <a class="bottom-nav-item" href="../pong/">
+      <i class="fas fa-table-tennis-paddle-ball"></i>
+      <span>Pong</span>
+    </a>
+    <a class="bottom-nav-item" href="../gta/">
+      <i class="fas fa-car"></i>
+      <span>GTA</span>
+    </a>
+    <a class="bottom-nav-item" href="../handout/">
+      <i class="fas fa-file-alt"></i>
+      <span>Handout</span>
     </a>
   </nav>
   <div id="content"><div class="loading">Laden...</div></div>

--- a/pong/index.html
+++ b/pong/index.html
@@ -4,12 +4,75 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Pong</title>
+  <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
+        crossorigin="anonymous" referrerpolicy="no-referrer">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: system-ui, sans-serif; background: #111; display: flex; justify-content: center; align-items: center; min-height: 100vh; padding-top: 48px; }
-    .va-topbar { position: fixed; top: 0; left: 0; right: 0; height: 48px; background: linear-gradient(135deg, #3498db, #2c3e50); display: flex; align-items: center; padding: 0 1rem; z-index: 9999; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
-    .va-topbar a { color: #fff; text-decoration: none; font-family: 'Segoe UI', system-ui, sans-serif; font-size: 0.95rem; font-weight: bold; display: flex; align-items: center; gap: 0.5rem; transition: opacity 0.2s; }
-    .va-topbar a:hover { opacity: 0.85; }
+
+    /* ── Desktop Navbar (>992px) ─────────────────────── */
+    .site-navbar {
+      display: none; position: fixed; top: 0; left: 0; right: 0;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      z-index: 1030; box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      align-items: center; justify-content: space-between;
+      padding: 0.5rem 1.5rem;
+    }
+    .site-navbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.3rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .site-navbar-links { display: flex; align-items: center; gap: 0.25rem; }
+    .site-navbar-link {
+      color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
+      padding: 0.4rem 0.8rem; border-radius: 6px; transition: background 0.2s, color 0.2s;
+    }
+    .site-navbar-link:hover, .site-navbar-link.active {
+      color: #fff; background: rgba(255,255,255,0.15);
+    }
+
+    /* ── Mobile Top Bar (<=992px) ────────────────────── */
+    .mobile-topbar {
+      position: fixed; top: 0; left: 0; right: 0; height: 56px;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 1rem; z-index: 1030;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .mobile-topbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.1rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .mobile-topbar-btn {
+      color: rgba(255,255,255,0.85); text-decoration: none; font-size: 1.1rem;
+      padding: 0.4rem; transition: color 0.2s;
+    }
+    .mobile-topbar-btn:hover { color: #fff; }
+
+    /* ── Mobile Bottom Nav (<=992px) ─────────────────── */
+    .bottom-nav {
+      position: fixed; bottom: 0; left: 0; right: 0; height: 60px;
+      background: #2c3e50; display: flex; justify-content: space-around; align-items: center;
+      z-index: 1030; box-shadow: 0 -2px 8px rgba(0,0,0,0.15);
+    }
+    .bottom-nav-item {
+      display: flex; flex-direction: column; align-items: center; gap: 0.15rem;
+      color: rgba(255,255,255,0.5); text-decoration: none; font-size: 0.65rem;
+      padding: 0.3rem 0.6rem; transition: color 0.2s;
+    }
+    .bottom-nav-item i { font-size: 1.15rem; }
+    .bottom-nav-item:hover, .bottom-nav-item.active { color: #fff; }
+    .bottom-nav-item.active i { color: #3498db; }
+
+    /* ── Responsive ──────────────────────────────────── */
+    @media (min-width: 992px) {
+      .site-navbar { display: flex; }
+      .mobile-topbar, .bottom-nav { display: none !important; }
+    }
+    @media (max-width: 991.98px) {
+      body { padding-top: 56px; padding-bottom: 60px; }
+    }
     #game { width: 420px; height: 500px; position: relative; }
     .pong-wrap { display:flex; flex-direction:column; align-items:center; height:100%; background:#111; padding:8px; box-sizing:border-box; }
     .pong-scores { display:flex; justify-content:space-between; width:300px; color:#fff; font:bold 14px/1 system-ui; padding:4px 0 6px; }
@@ -22,10 +85,50 @@
   </style>
 </head>
 <body>
-  <nav class="va-topbar">
-    <a href="../">
-      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
-      Vibecoding Academy
+  <!-- Desktop Navbar (>992px) -->
+  <nav class="site-navbar">
+    <a class="site-navbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <div class="site-navbar-links">
+      <a class="site-navbar-link" href="../">Home</a>
+      <a class="site-navbar-link active" href="../pong/">Pong</a>
+      <a class="site-navbar-link" href="../gta/">GTA</a>
+      <a class="site-navbar-link" href="../handout/">Handout</a>
+      <a class="site-navbar-link" href="https://github.com/Fauteck/vibecoding-academy" target="_blank" rel="noopener">
+        <i class="fab fa-github"></i> GitHub
+      </a>
+    </div>
+  </nav>
+
+  <!-- Mobile Top Bar (<=992px) -->
+  <div class="mobile-topbar">
+    <a class="mobile-topbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <a href="https://github.com/Fauteck/vibecoding-academy"
+       class="mobile-topbar-btn" target="_blank" rel="noopener" aria-label="GitHub">
+      <i class="fab fa-github"></i>
+    </a>
+  </div>
+
+  <!-- Mobile Bottom Navigation (<=992px) -->
+  <nav class="bottom-nav">
+    <a class="bottom-nav-item" href="../">
+      <i class="fas fa-home"></i>
+      <span>Home</span>
+    </a>
+    <a class="bottom-nav-item active" href="../pong/">
+      <i class="fas fa-table-tennis-paddle-ball"></i>
+      <span>Pong</span>
+    </a>
+    <a class="bottom-nav-item" href="../gta/">
+      <i class="fas fa-car"></i>
+      <span>GTA</span>
+    </a>
+    <a class="bottom-nav-item" href="../handout/">
+      <i class="fas fa-file-alt"></i>
+      <span>Handout</span>
     </a>
   </nav>
   <div id="game"></div>


### PR DESCRIPTION
## Summary

- All subpages (Pong, GTA, Handout, Ideen-Viewer) now have the same desktop navbar and mobile bottom navigation as the landing page
- **Desktop (>992px)**: Sticky navbar with links to Home, Pong, GTA, Handout, GitHub — active page is highlighted
- **Mobile (≤992px)**: Top bar with brand + GitHub icon, plus bottom navigation with Home, Pong, GTA, Handout
- GTA mobile touch controls repositioned to avoid overlap with bottom nav
- Font Awesome CDN added to all subpages for navigation icons

## Test plan

- [ ] Desktop (>992px): Verify sticky navbar appears on all subpages with correct active state
- [ ] Mobile (≤992px): Verify top bar and bottom navigation appear on all subpages
- [ ] Navigate between pages using the navbar/bottom nav links
- [ ] Pong: Game plays correctly, navbar doesn't overlap canvas
- [ ] GTA: Touch controls not obscured by bottom nav on mobile, game plays correctly
- [ ] Handout: Document scrolls properly, print view hides navigation
- [ ] Ideen-Viewer: Page loads and displays markdown content correctly

https://claude.ai/code/session_01S5c7MDrTuEY2CbfCoJp34U