### PR TITLE
Add weekend duty planning application

### DIFF
--- a/Wochenendplanung/index.html
+++ b/Wochenendplanung/index.html
@@ -1,0 +1,790 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wochenendplanung</title>
+
+  <!-- Bootstrap 5.3.2 -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
+        crossorigin="anonymous">
+
+  <!-- Font Awesome 6.4.2 -->
+  <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
+        crossorigin="anonymous" referrerpolicy="no-referrer">
+
+  <style>
+    /* ── Design Tokens ────────────────────────────────── */
+    :root {
+      --primary-color:   #5B8BD6;
+      --secondary-color: #3D5A8C;
+      --success-color:   #5CC6A7;
+      --danger-color:    #D46B6B;
+      --warning-color:   #D4A55B;
+      --info-color:      #6BB8D4;
+      --bg-page:         #EEF2F7;
+      --bg-card:         rgba(255, 255, 255, 0.85);
+      --text-primary:    #2D3748;
+      --text-muted:      #7A8599;
+      --border-color:    #D4DCE8;
+      --border-radius-card: 10px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background: var(--bg-page);
+      color: var(--text-primary);
+      padding-top: 48px;
+      min-height: 100vh;
+    }
+
+    /* ── Desktop Navbar (>992px) ─────────────────────── */
+    .site-navbar {
+      display: none; position: fixed; top: 0; left: 0; right: 0;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      z-index: 1030; box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      align-items: center; justify-content: space-between;
+      padding: 0.5rem 1.5rem;
+    }
+    .site-navbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.3rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .site-navbar-links { display: flex; align-items: center; gap: 0.25rem; }
+    .site-navbar-link {
+      color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
+      padding: 0.4rem 0.8rem; border-radius: 6px; transition: background 0.2s, color 0.2s;
+    }
+    .site-navbar-link:hover, .site-navbar-link.active {
+      color: #fff; background: rgba(255,255,255,0.15);
+    }
+
+    /* ── Mobile Top Bar (<=992px) ────────────────────── */
+    .mobile-topbar {
+      position: fixed; top: 0; left: 0; right: 0; height: 56px;
+      background: linear-gradient(135deg, #3498db, #2c3e50);
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 1rem; z-index: 1030;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .mobile-topbar-brand {
+      color: #fff; text-decoration: none; font-size: 1.1rem; font-weight: bold;
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .mobile-topbar-btn {
+      color: rgba(255,255,255,0.85); text-decoration: none; font-size: 1.1rem;
+      padding: 0.4rem; transition: color 0.2s;
+    }
+    .mobile-topbar-btn:hover { color: #fff; }
+
+    /* ── Mobile Bottom Nav (<=992px) ─────────────────── */
+    .bottom-nav {
+      position: fixed; bottom: 0; left: 0; right: 0; height: 60px;
+      background: #2c3e50; display: flex; justify-content: space-around; align-items: center;
+      z-index: 1030; box-shadow: 0 -2px 8px rgba(0,0,0,0.15);
+    }
+    .bottom-nav-item {
+      display: flex; flex-direction: column; align-items: center; gap: 0.15rem;
+      color: rgba(255,255,255,0.5); text-decoration: none; font-size: 0.65rem;
+      padding: 0.3rem 0.6rem; transition: color 0.2s;
+    }
+    .bottom-nav-item i { font-size: 1.15rem; }
+    .bottom-nav-item:hover, .bottom-nav-item.active { color: #fff; }
+    .bottom-nav-item.active i { color: #3498db; }
+
+    /* ── Responsive Nav ─────────────────────────────── */
+    @media (min-width: 992px) {
+      .site-navbar { display: flex; }
+      .mobile-topbar, .bottom-nav { display: none !important; }
+    }
+    @media (max-width: 991.98px) {
+      body { padding-top: 56px; padding-bottom: 60px; }
+    }
+
+    /* ── Page Header ────────────────────────────────── */
+    .page-header {
+      background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+      color: #fff; padding: 2rem 1rem; text-align: center; margin-bottom: 1.5rem;
+    }
+    .page-header h1 { font-size: 1.8rem; font-weight: 700; margin-bottom: 0.3rem; }
+    .page-header p { opacity: 0.85; font-size: 0.95rem; margin: 0; }
+
+    /* ── Cards & Form ───────────────────────────────── */
+    .plan-card {
+      background: var(--bg-card); border: 1px solid var(--border-color);
+      border-radius: var(--border-radius-card); padding: 1.25rem;
+      margin-bottom: 1rem; backdrop-filter: blur(4px);
+    }
+    .plan-card h5 {
+      font-size: 1rem; font-weight: 600; margin-bottom: 1rem;
+      color: var(--secondary-color); display: flex; align-items: center; gap: 0.5rem;
+    }
+
+    .form-select, .form-control { border-color: var(--border-color); font-size: 0.9rem; }
+    .form-select:focus, .form-control:focus {
+      border-color: var(--primary-color);
+      box-shadow: 0 0 0 0.2rem rgba(91, 139, 214, 0.25);
+    }
+
+    .btn-primary {
+      background: var(--primary-color); border-color: var(--primary-color);
+      font-weight: 600; padding: 0.5rem 1.5rem;
+    }
+    .btn-primary:hover {
+      background: var(--secondary-color); border-color: var(--secondary-color);
+    }
+
+    /* ── Filter Bar ─────────────────────────────────── */
+    .filter-bar {
+      display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .filter-bar .form-check-input:checked {
+      background-color: var(--primary-color); border-color: var(--primary-color);
+    }
+
+    /* ── Weekend Table ──────────────────────────────── */
+    .weekend-table { width: 100%; border-collapse: collapse; font-size: 0.88rem; }
+    .weekend-table th {
+      background: var(--secondary-color); color: #fff;
+      padding: 0.6rem 0.75rem; font-weight: 600; font-size: 0.8rem;
+      text-transform: uppercase; letter-spacing: 0.03em;
+      position: sticky; top: 0; z-index: 1;
+    }
+    .weekend-table td { padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border-color); }
+    .weekend-table tr:hover td { background: rgba(91, 139, 214, 0.06); }
+    .weekend-table tr.is-past td { opacity: 0.45; }
+
+    /* ── Status Badges ──────────────────────────────── */
+    .badge-vakant {
+      background: var(--success-color); color: #fff;
+      padding: 0.25em 0.6em; border-radius: 4px; font-size: 0.78rem; font-weight: 600;
+    }
+    .badge-besetzt {
+      background: var(--text-muted); color: #fff;
+      padding: 0.25em 0.6em; border-radius: 4px; font-size: 0.78rem; font-weight: 600;
+    }
+
+    /* ── Mobile Cards (<=768px) ─────────────────────── */
+    .weekend-card {
+      background: var(--bg-card); border: 1px solid var(--border-color);
+      border-radius: var(--border-radius-card); padding: 0.85rem 1rem;
+      margin-bottom: 0.6rem; display: flex; justify-content: space-between;
+      align-items: center; gap: 0.75rem;
+    }
+    .weekend-card.is-past { opacity: 0.45; }
+    .weekend-card-left { flex: 1; min-width: 0; }
+    .weekend-card-kw {
+      font-weight: 700; font-size: 0.82rem; color: var(--secondary-color); margin-bottom: 0.15rem;
+    }
+    .weekend-card-date { font-size: 0.8rem; color: var(--text-muted); }
+    .weekend-card-right { text-align: right; flex-shrink: 0; }
+    .weekend-card-person { font-size: 0.82rem; font-weight: 600; margin-top: 0.2rem; }
+
+    .desktop-table { display: block; }
+    .mobile-cards { display: none; }
+
+    @media (max-width: 768px) {
+      .desktop-table { display: none; }
+      .mobile-cards { display: block; }
+      .page-header h1 { font-size: 1.4rem; }
+      .page-header p { font-size: 0.85rem; }
+    }
+
+    /* ── Toast ──────────────────────────────────────── */
+    .toast-container { position: fixed; top: 70px; right: 1rem; z-index: 1080; }
+
+    /* ── Stats ──────────────────────────────────────── */
+    .stats-row {
+      display: flex; gap: 0.75rem; margin-bottom: 1rem; flex-wrap: wrap;
+    }
+    .stat-badge {
+      background: var(--bg-card); border: 1px solid var(--border-color);
+      border-radius: 8px; padding: 0.5rem 0.85rem;
+      font-size: 0.82rem; display: flex; align-items: center; gap: 0.4rem;
+    }
+    .stat-badge strong { font-size: 1.1rem; }
+    .stat-vakant strong { color: var(--success-color); }
+    .stat-besetzt strong { color: var(--text-muted); }
+    .stat-total strong { color: var(--primary-color); }
+
+    /* ── Footer ─────────────────────────────────────── */
+    .site-footer {
+      text-align: center; padding: 1.5rem 1rem; margin-top: 2rem;
+      color: var(--text-muted); font-size: 0.78rem;
+      border-top: 1px solid var(--border-color);
+    }
+  </style>
+</head>
+<body>
+
+  <!-- ══════════════════════════════════════════════════ -->
+  <!--  Desktop Navbar (>992px)                          -->
+  <!-- ══════════════════════════════════════════════════ -->
+  <nav class="site-navbar">
+    <a class="site-navbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <div class="site-navbar-links">
+      <a class="site-navbar-link" href="../">Home</a>
+      <a class="site-navbar-link" href="../pong/">Pong</a>
+      <a class="site-navbar-link" href="../gta/">GTA</a>
+      <a class="site-navbar-link" href="../handout/">Handout</a>
+      <a class="site-navbar-link active" href="../Wochenendplanung/">Planung</a>
+      <a class="site-navbar-link" href="https://github.com/Fauteck/vibecoding-academy" target="_blank" rel="noopener">
+        <i class="fab fa-github"></i> GitHub
+      </a>
+    </div>
+  </nav>
+
+  <!-- ══════════════════════════════════════════════════ -->
+  <!--  Mobile Top Bar (<=992px)                         -->
+  <!-- ══════════════════════════════════════════════════ -->
+  <div class="mobile-topbar">
+    <a class="mobile-topbar-brand" href="../">
+      <i class="fas fa-code"></i> Vibecoding Academy
+    </a>
+    <a href="https://github.com/Fauteck/vibecoding-academy"
+       class="mobile-topbar-btn" target="_blank" rel="noopener" aria-label="GitHub">
+      <i class="fab fa-github"></i>
+    </a>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════ -->
+  <!--  Mobile Bottom Navigation (<=992px)               -->
+  <!-- ══════════════════════════════════════════════════ -->
+  <nav class="bottom-nav">
+    <a class="bottom-nav-item" href="../">
+      <i class="fas fa-home"></i>
+      <span>Home</span>
+    </a>
+    <a class="bottom-nav-item" href="../pong/">
+      <i class="fas fa-table-tennis-paddle-ball"></i>
+      <span>Pong</span>
+    </a>
+    <a class="bottom-nav-item" href="../gta/">
+      <i class="fas fa-car"></i>
+      <span>GTA</span>
+    </a>
+    <a class="bottom-nav-item" href="../handout/">
+      <i class="fas fa-file-alt"></i>
+      <span>Handout</span>
+    </a>
+    <a class="bottom-nav-item active" href="../Wochenendplanung/">
+      <i class="fas fa-calendar-check"></i>
+      <span>Planung</span>
+    </a>
+  </nav>
+
+  <!-- ══════════════════════════════════════════════════ -->
+  <!--  Page Header                                      -->
+  <!-- ══════════════════════════════════════════════════ -->
+  <div class="page-header">
+    <h1><i class="fas fa-calendar-check me-2"></i>Wochenenddienst-Planung</h1>
+    <p>Übersicht und Eintragung offener Wochenenddienste</p>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════ -->
+  <!--  Main Content                                     -->
+  <!-- ══════════════════════════════════════════════════ -->
+  <main class="container-fluid" style="max-width: 1100px; margin: 0 auto; padding: 0 1rem 2rem;">
+
+    <div class="row g-3">
+
+      <!-- ── Formular (links auf Desktop) ──────────── -->
+      <div class="col-lg-4">
+        <div class="plan-card">
+          <h5><i class="fas fa-pen"></i> Eintragung</h5>
+          <form id="assignment-form" autocomplete="off">
+            <div class="mb-3">
+              <label for="employee-select" class="form-label small fw-semibold">Kollege / Kollegin</label>
+              <select id="employee-select" class="form-select" required>
+                <option value="" disabled selected>Bitte auswählen…</option>
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="weekend-select" class="form-label small fw-semibold">Freies Wochenende</label>
+              <select id="weekend-select" class="form-select" required>
+                <option value="" disabled selected>Bitte auswählen…</option>
+              </select>
+            </div>
+            <button type="submit" class="btn btn-primary w-100" id="submit-btn">
+              <i class="fas fa-check me-1"></i> Eintragen
+            </button>
+          </form>
+        </div>
+
+        <!-- ── Statistik ───────────────────────────── -->
+        <div class="stats-row" id="stats-row"></div>
+      </div>
+
+      <!-- ── Übersicht (rechts auf Desktop) ────────── -->
+      <div class="col-lg-8">
+        <div class="plan-card" style="padding: 0.75rem;">
+          <div style="padding: 0.5rem 0.5rem 0;">
+            <h5 style="margin-bottom: 0.6rem;"><i class="fas fa-list"></i> Wochenend-Übersicht</h5>
+            <div class="filter-bar">
+              <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="filter-vacant">
+                <label class="form-check-label small" for="filter-vacant">Nur vakante anzeigen</label>
+              </div>
+              <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="filter-hide-past">
+                <label class="form-check-label small" for="filter-hide-past">Vergangene ausblenden</label>
+              </div>
+            </div>
+          </div>
+
+          <!-- Desktop: Table -->
+          <div class="desktop-table">
+            <div style="overflow-x: auto;">
+              <table class="weekend-table">
+                <thead>
+                  <tr>
+                    <th>KW</th>
+                    <th>Wochenende</th>
+                    <th>Status</th>
+                    <th>Eingetragen</th>
+                  </tr>
+                </thead>
+                <tbody id="table-body"></tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- Mobile: Cards -->
+          <div class="mobile-cards" id="mobile-cards"></div>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <!-- ══════════════════════════════════════════════════ -->
+  <!--  Toast Container                                  -->
+  <!-- ══════════════════════════════════════════════════ -->
+  <div class="toast-container" id="toast-container"></div>
+
+  <!-- ══════════════════════════════════════════════════ -->
+  <!--  Footer                                           -->
+  <!-- ══════════════════════════════════════════════════ -->
+  <footer class="site-footer">
+    Vibecoding Academy &middot; Wochenenddienst-Planung
+  </footer>
+
+  <!-- Bootstrap JS Bundle -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+          integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+          crossorigin="anonymous"></script>
+
+  <script>
+  (function () {
+    'use strict';
+
+    /* ── Konfiguration ────────────────────────────── */
+    var STORAGE_KEY = 'wochenendplanung_assignments';
+    var YEAR = 2026;
+
+    var EMPLOYEES = [
+      { id: 1, name: 'Max Mustermann' },
+      { id: 2, name: 'Anna Beispiel' },
+      { id: 3, name: 'Thomas Schmidt' },
+      { id: 4, name: 'Lisa Weber' },
+      { id: 5, name: 'Michael Braun' },
+      { id: 6, name: 'Sarah Koch' },
+      { id: 7, name: 'Daniel Fischer' },
+      { id: 8, name: 'Julia Wagner' },
+      { id: 9, name: 'Patrick Hoffmann' },
+      { id: 10, name: 'Nina Becker' }
+    ];
+
+    /* ── DOM-Referenzen ───────────────────────────── */
+    var employeeSelect = document.getElementById('employee-select');
+    var weekendSelect = document.getElementById('weekend-select');
+    var form = document.getElementById('assignment-form');
+    var tableBody = document.getElementById('table-body');
+    var mobileCards = document.getElementById('mobile-cards');
+    var filterVacant = document.getElementById('filter-vacant');
+    var filterHidePast = document.getElementById('filter-hide-past');
+    var statsRow = document.getElementById('stats-row');
+    var toastContainer = document.getElementById('toast-container');
+
+    /* ── Hilfsfunktionen ──────────────────────────── */
+
+    /** ISO 8601 Kalenderwoche berechnen */
+    function getISOWeek(date) {
+      var d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+      var dayNum = d.getUTCDay() || 7;
+      d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+      var yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+      return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+    }
+
+    /** Datum als TT.MM.JJJJ formatieren */
+    function formatDate(date) {
+      var d = date.getDate().toString();
+      var m = (date.getMonth() + 1).toString();
+      if (d.length < 2) d = '0' + d;
+      if (m.length < 2) m = '0' + m;
+      return d + '.' + m + '.' + date.getFullYear();
+    }
+
+    /** Prüfen ob ein Wochenende in der Vergangenheit liegt */
+    function isPast(endDate) {
+      var today = new Date();
+      today.setHours(0, 0, 0, 0);
+      return endDate < today;
+    }
+
+    /* ── Wochenenden generieren ───────────────────── */
+    function generateWeekends(year) {
+      var weekends = [];
+      var id = 1;
+      var date = new Date(year, 0, 1);
+
+      // Zum ersten Samstag springen
+      while (date.getDay() !== 6) {
+        date.setDate(date.getDate() + 1);
+      }
+
+      while (date.getFullYear() === year) {
+        var saturday = new Date(date);
+        var sunday = new Date(date);
+        sunday.setDate(sunday.getDate() + 1);
+
+        weekends.push({
+          id: id++,
+          calendarWeek: getISOWeek(saturday),
+          startDate: saturday,
+          endDate: sunday,
+          assignedEmployeeId: null,
+          assignedEmployeeName: null,
+          status: 'vacant'
+        });
+
+        date.setDate(date.getDate() + 7);
+      }
+
+      return weekends;
+    }
+
+    /* ── State ────────────────────────────────────── */
+    var weekends = generateWeekends(YEAR);
+
+    /** Zuweisungen aus localStorage laden */
+    function loadAssignments() {
+      var data;
+      try {
+        data = JSON.parse(localStorage.getItem(STORAGE_KEY));
+      } catch (e) {
+        data = null;
+      }
+      if (!Array.isArray(data)) return;
+
+      var map = {};
+      for (var i = 0; i < data.length; i++) {
+        map[data[i].weekendId] = data[i];
+      }
+
+      for (var j = 0; j < weekends.length; j++) {
+        var w = weekends[j];
+        if (map[w.id]) {
+          w.assignedEmployeeId = map[w.id].employeeId;
+          w.assignedEmployeeName = map[w.id].employeeName;
+          w.status = 'assigned';
+        }
+      }
+    }
+
+    /** Zuweisungen in localStorage speichern */
+    function saveAssignments() {
+      var data = [];
+      for (var i = 0; i < weekends.length; i++) {
+        var w = weekends[i];
+        if (w.status === 'assigned') {
+          data.push({
+            weekendId: w.id,
+            employeeId: w.assignedEmployeeId,
+            employeeName: w.assignedEmployeeName
+          });
+        }
+      }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    }
+
+    /* ── Rendering ────────────────────────────────── */
+
+    /** Mitarbeiter-Dropdown befüllen */
+    function renderEmployeeSelect() {
+      for (var i = 0; i < EMPLOYEES.length; i++) {
+        var opt = document.createElement('option');
+        opt.value = EMPLOYEES[i].id;
+        opt.textContent = EMPLOYEES[i].name;
+        employeeSelect.appendChild(opt);
+      }
+    }
+
+    /** Wochenend-Dropdown aktualisieren (nur vakante) */
+    function renderWeekendSelect() {
+      // Aktuelle Auswahl merken
+      var currentVal = weekendSelect.value;
+
+      // Alle Optionen entfernen außer Placeholder
+      while (weekendSelect.options.length > 1) {
+        weekendSelect.remove(1);
+      }
+
+      for (var i = 0; i < weekends.length; i++) {
+        var w = weekends[i];
+        if (w.status === 'vacant' && !isPast(w.endDate)) {
+          var opt = document.createElement('option');
+          opt.value = w.id;
+          opt.textContent = 'KW ' + w.calendarWeek + ' — ' + formatDate(w.startDate) + ' / ' + formatDate(w.endDate);
+          weekendSelect.appendChild(opt);
+        }
+      }
+
+      // Auswahl wiederherstellen falls möglich
+      weekendSelect.value = currentVal;
+      if (!weekendSelect.value) {
+        weekendSelect.selectedIndex = 0;
+      }
+    }
+
+    /** Statistik rendern */
+    function renderStats() {
+      var total = weekends.length;
+      var vacant = 0;
+      var assigned = 0;
+
+      for (var i = 0; i < weekends.length; i++) {
+        if (weekends[i].status === 'vacant') vacant++;
+        else assigned++;
+      }
+
+      statsRow.innerHTML = '';
+
+      var stats = [
+        { cls: 'stat-total', icon: 'fa-calendar', label: 'Gesamt', val: total },
+        { cls: 'stat-vakant', icon: 'fa-calendar-check', label: 'Vakant', val: vacant },
+        { cls: 'stat-besetzt', icon: 'fa-calendar-xmark', label: 'Besetzt', val: assigned }
+      ];
+
+      for (var j = 0; j < stats.length; j++) {
+        var s = stats[j];
+        var div = document.createElement('div');
+        div.className = 'stat-badge ' + s.cls;
+
+        var icon = document.createElement('i');
+        icon.className = 'fas ' + s.icon;
+        div.appendChild(icon);
+
+        var strong = document.createElement('strong');
+        strong.textContent = s.val;
+        div.appendChild(strong);
+
+        var span = document.createElement('span');
+        span.textContent = s.label;
+        div.appendChild(span);
+
+        statsRow.appendChild(div);
+      }
+    }
+
+    /** Übersichtstabelle rendern */
+    function renderOverview() {
+      var showVacantOnly = filterVacant.checked;
+      var hidePast = filterHidePast.checked;
+
+      // Desktop-Tabelle
+      tableBody.innerHTML = '';
+
+      // Mobile-Karten
+      mobileCards.innerHTML = '';
+
+      for (var i = 0; i < weekends.length; i++) {
+        var w = weekends[i];
+        var past = isPast(w.endDate);
+
+        if (showVacantOnly && w.status !== 'vacant') continue;
+        if (hidePast && past) continue;
+
+        // ── Tabellenzeile ──
+        var tr = document.createElement('tr');
+        if (past) tr.className = 'is-past';
+
+        var tdKw = document.createElement('td');
+        tdKw.textContent = 'KW ' + w.calendarWeek;
+        tr.appendChild(tdKw);
+
+        var tdDate = document.createElement('td');
+        tdDate.textContent = formatDate(w.startDate) + ' – ' + formatDate(w.endDate);
+        tr.appendChild(tdDate);
+
+        var tdStatus = document.createElement('td');
+        var badge = document.createElement('span');
+        if (w.status === 'vacant') {
+          badge.className = 'badge-vakant';
+          badge.textContent = 'Vakant';
+        } else {
+          badge.className = 'badge-besetzt';
+          badge.textContent = 'Besetzt';
+        }
+        tdStatus.appendChild(badge);
+        tr.appendChild(tdStatus);
+
+        var tdPerson = document.createElement('td');
+        tdPerson.textContent = w.assignedEmployeeName || '–';
+        tr.appendChild(tdPerson);
+
+        tableBody.appendChild(tr);
+
+        // ── Mobile-Karte ──
+        var card = document.createElement('div');
+        card.className = 'weekend-card';
+        if (past) card.className += ' is-past';
+
+        var left = document.createElement('div');
+        left.className = 'weekend-card-left';
+
+        var kwDiv = document.createElement('div');
+        kwDiv.className = 'weekend-card-kw';
+        kwDiv.textContent = 'KW ' + w.calendarWeek;
+        left.appendChild(kwDiv);
+
+        var dateDiv = document.createElement('div');
+        dateDiv.className = 'weekend-card-date';
+        dateDiv.textContent = formatDate(w.startDate) + ' – ' + formatDate(w.endDate);
+        left.appendChild(dateDiv);
+
+        card.appendChild(left);
+
+        var right = document.createElement('div');
+        right.className = 'weekend-card-right';
+
+        var mbadge = document.createElement('span');
+        if (w.status === 'vacant') {
+          mbadge.className = 'badge-vakant';
+          mbadge.textContent = 'Vakant';
+        } else {
+          mbadge.className = 'badge-besetzt';
+          mbadge.textContent = 'Besetzt';
+        }
+        right.appendChild(mbadge);
+
+        if (w.assignedEmployeeName) {
+          var personDiv = document.createElement('div');
+          personDiv.className = 'weekend-card-person';
+          personDiv.textContent = w.assignedEmployeeName;
+          right.appendChild(personDiv);
+        }
+
+        card.appendChild(right);
+        mobileCards.appendChild(card);
+      }
+    }
+
+    /* ── Toast-Benachrichtigungen ─────────────────── */
+    function showToast(message, type) {
+      var bgClass = type === 'success' ? 'bg-success' : 'bg-danger';
+
+      var toastEl = document.createElement('div');
+      toastEl.className = 'toast align-items-center text-white ' + bgClass + ' border-0';
+      toastEl.setAttribute('role', 'alert');
+
+      var flex = document.createElement('div');
+      flex.className = 'd-flex';
+
+      var body = document.createElement('div');
+      body.className = 'toast-body';
+      body.textContent = message;
+      flex.appendChild(body);
+
+      var closeBtn = document.createElement('button');
+      closeBtn.type = 'button';
+      closeBtn.className = 'btn-close btn-close-white me-2 m-auto';
+      closeBtn.setAttribute('data-bs-dismiss', 'toast');
+      closeBtn.setAttribute('aria-label', 'Schließen');
+      flex.appendChild(closeBtn);
+
+      toastEl.appendChild(flex);
+      toastContainer.appendChild(toastEl);
+
+      var toast = new bootstrap.Toast(toastEl, { delay: 3000 });
+      toast.show();
+
+      toastEl.addEventListener('hidden.bs.toast', function () {
+        toastEl.remove();
+      });
+    }
+
+    /* ── Formular-Handling ────────────────────────── */
+    function handleSubmit(e) {
+      e.preventDefault();
+
+      var empId = parseInt(employeeSelect.value, 10);
+      var weekendId = parseInt(weekendSelect.value, 10);
+
+      if (!empId || !weekendId) {
+        showToast('Bitte Kollege und Wochenende auswählen.', 'error');
+        return;
+      }
+
+      // Mitarbeiter finden
+      var employee = null;
+      for (var i = 0; i < EMPLOYEES.length; i++) {
+        if (EMPLOYEES[i].id === empId) { employee = EMPLOYEES[i]; break; }
+      }
+
+      // Wochenende finden und prüfen
+      var weekend = null;
+      for (var j = 0; j < weekends.length; j++) {
+        if (weekends[j].id === weekendId) { weekend = weekends[j]; break; }
+      }
+
+      if (!employee || !weekend) {
+        showToast('Ungültige Auswahl. Bitte erneut versuchen.', 'error');
+        return;
+      }
+
+      if (weekend.status === 'assigned') {
+        showToast('Dieses Wochenende ist bereits vergeben.', 'error');
+        return;
+      }
+
+      // Eintragung
+      weekend.assignedEmployeeId = employee.id;
+      weekend.assignedEmployeeName = employee.name;
+      weekend.status = 'assigned';
+
+      saveAssignments();
+      renderWeekendSelect();
+      renderOverview();
+      renderStats();
+
+      // Formular zurücksetzen
+      form.reset();
+
+      showToast(employee.name + ' wurde für KW ' + weekend.calendarWeek + ' eingetragen.', 'success');
+    }
+
+    /* ── Initialisierung ──────────────────────────── */
+    loadAssignments();
+    renderEmployeeSelect();
+    renderWeekendSelect();
+    renderOverview();
+    renderStats();
+
+    form.addEventListener('submit', handleSubmit);
+    filterVacant.addEventListener('change', renderOverview);
+    filterHidePast.addEventListener('change', renderOverview);
+
+  })();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -557,6 +557,15 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
+        <a class="card text-decoration-none h-100" href="./Wochenendplanung/">
+          <div class="card-body text-center">
+            <div class="fs-1 mb-2">📅</div>
+            <h6 class="card-title">Wochenendplanung</h6>
+            <p class="card-text text-muted small">Wochenenddienst-Planung und Übersicht</p>
+          </div>
+        </a>
+      </div>
+      <div class="col-md-4 col-sm-6">
         <div class="card h-100" style="border: 2px dashed var(--border-color);">
           <div class="card-body text-center text-muted d-flex flex-column justify-content-center">
             <div class="fs-1 mb-2">🚀</div>


### PR DESCRIPTION
## Summary
This PR introduces a new weekend duty planning application ("Wochenendplanung") that allows employees to view and register for available weekend shifts throughout the year.

## Key Changes
- **New application**: Created a complete weekend duty planning interface at `/Wochenendplanung/index.html`
  - Responsive design with desktop navbar and mobile bottom navigation
  - Form-based employee assignment to weekend shifts
  - Real-time overview with desktop table and mobile card layouts
  - Filter options to show only vacant slots or hide past weekends
  - Statistics dashboard showing total, vacant, and assigned weekend counts
  - LocalStorage persistence for all assignments

- **Homepage integration**: Added a new card link on the main index.html to navigate to the planning application

## Implementation Details
- **Data generation**: Automatically generates all 52 weekends for 2026 with ISO 8601 calendar week numbers
- **Employee management**: Pre-configured list of 10 employees that can be assigned to weekends
- **Responsive UI**: 
  - Desktop (>992px): Two-column layout with form on left, overview table on right
  - Tablet/Mobile (≤768px): Stacked layout with card-based weekend display
  - Mobile navigation: Fixed top bar and bottom navigation for ≤992px viewports
- **State management**: Assignments are persisted to localStorage and restored on page load
- **User feedback**: Toast notifications for successful assignments and error handling
- **Styling**: Consistent design using CSS custom properties and Bootstrap 5.3.2 for component styling

https://claude.ai/code/session_01EQgcvVZtdAHPrPEPG6B3z2