### PR TITLE
Add "Linktipps" section with AI newsletters and podcasts

### DIFF
--- a/handout/index.html
+++ b/handout/index.html
@@ -703,6 +703,44 @@
 
     <!-- ───────────────────────────────────────────── -->
 
+    <h2 id="linktipps">Linktipps: Newsletter &amp; Podcasts</h2>
+
+    <p>Wer am Ball bleiben möchte, findet hier empfehlenswerte Newsletter und Podcasts rund um KI:</p>
+
+    <h3>Newsletter</h3>
+
+    <ul>
+      <li>
+        <strong><a href="https://www.ainauten.com/" target="_blank" rel="noopener">AINAUTEN</a></strong> -- Deutschsprachiger KI-Newsletter, der 3× pro Woche in 5 Minuten die relevantesten KI-News, Tools und Hacks liefert. Über 75.000 Abonnenten.<br>
+        <em>Herausgeber: AINAUTEN Team</em>
+      </li>
+      <li>
+        <strong><a href="https://www.implicator.ai" target="_blank" rel="noopener">Implicator.ai -- Strategic AI Briefing from San Francisco</a></strong> -- Täglicher englischsprachiger KI-Newsletter (werktags um 6 AM PT), der in unter 3 Minuten die 5 wichtigsten KI-Entwicklungen zusammenfasst -- mit journalistischem Anspruch und kritischer Einordnung statt Hype.<br>
+        <em>Autor: Marcus Schuler, Schuler Media LLC (San Francisco)</em>
+      </li>
+    </ul>
+
+    <h3>Podcasts</h3>
+
+    <ul>
+      <li>
+        <strong><a href="https://www.heise.de/thema/KI-Update" target="_blank" rel="noopener">KI-Update -- ein heise-Podcast</a></strong> -- Erscheint 3× pro Woche (Mo, Mi, Fr) und fasst die wichtigsten KI-Entwicklungen zusammen. An abwechselnden Freitagen gibt es einen Deep Dive mit Experten. Produziert in Zusammenarbeit mit The Decoder.<br>
+        <em>Herausgeber: heise online; Moderation: Isabel Grünewald</em>
+      </li>
+      <li>
+        <strong><a href="https://t3n-meisterprompter.podigee.io/" target="_blank" rel="noopener">t3n MeisterPrompter</a></strong> -- Wöchentlicher Podcast (mittwochs), der konkrete, direkt umsetzbare Prompt-Anleitungen für den Arbeitsalltag vorstellt und einmal im Monat häufige Prompt-Fehler aufgreift.<br>
+        <em>Herausgeber: t3n Magazin; Moderation: Susanne Renate Schneider &amp; Stella-Sophie Wojtczak</em>
+      </li>
+    </ul>
+
+    <div class="highlight-box highlight-blue">
+      <p><strong>Tipp:</strong> Abonniere mindestens einen Newsletter und einen Podcast -- so bleibst du ohne großen Aufwand auf dem Laufenden.</p>
+    </div>
+
+    <hr>
+
+    <!-- ───────────────────────────────────────────── -->
+
     <h2 id="fazit">Fazit</h2>
 
     <p>Vibe-Coding macht Entwicklung zugänglicher, schneller und kreativer.</p>


### PR DESCRIPTION
## Summary
Added a new "Linktipps: Newsletter & Podcasts" section to the handout that curates recommended German and English language resources for staying updated on AI developments.

## Changes
- Added new section with ID `linktipps` positioned before the "Fazit" section
- **Newsletters subsection**: Featured 2 curated newsletters
  - AINAUTEN (German, 3× weekly)
  - Implicator.ai (English, daily weekday briefing)
- **Podcasts subsection**: Featured 2 curated podcasts
  - KI-Update by heise (German, 3× weekly)
  - t3n MeisterPrompter (German, weekly)
- Each resource includes title, description, frequency, and attribution
- Added a blue highlight box with a recommendation to subscribe to at least one newsletter and one podcast
- Included horizontal rule separator for visual consistency

## Implementation Details
- All external links open in new tabs with `target="_blank" rel="noopener"`
- Metadata (publishers/authors) formatted in italics for visual distinction
- Follows existing HTML structure and styling conventions used throughout the document

https://claude.ai/code/session_01Q3RN8vYKDGUSKQXtSj8A5z