### PR TITLE
Remove workshop project badges from portfolio section

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,20 +633,6 @@
           </div>
         </div>
 
-        <div class="d-flex flex-wrap gap-2 justify-content-center mb-0">
-          <span class="badge bg-light text-dark border">
-            <i class="fas fa-globe me-1"></i> Website
-          </span>
-          <span class="badge bg-light text-dark border">
-            <i class="fas fa-check-square me-1"></i> To-Do-App
-          </span>
-          <span class="badge bg-light text-dark border">
-            <i class="fas fa-wallet me-1"></i> Finanzüberblick
-          </span>
-          <span class="badge bg-light text-dark border">
-            <i class="fas fa-tachometer-alt me-1"></i> Dashboard
-          </span>
-        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
Removed a set of project badge elements from the workshop section of the portfolio page.

## Changes Made
- Deleted the badge container and four project badges (Website, To-Do-App, Finanzüberblick, Dashboard) that were displayed in the workshop section
- These badges were styled with Bootstrap classes and included Font Awesome icons

## Details
The removed section consisted of a flexbox container with four badge elements that showcased workshop projects. This appears to be a cleanup or reorganization of the portfolio content, possibly moving these project references elsewhere or removing them from the workshop section entirely.

https://claude.ai/code/session_016ieH3ahWqG7KuRKqpR93H5