### PR TITLE
Add semi-transparent overlay to background images

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       background:
+        linear-gradient(rgba(238, 242, 247, 0.45), rgba(238, 242, 247, 0.45)),
         url('./images/content-bg.jpg') top center/cover no-repeat fixed,
         var(--bg-page);
       color: var(--text-primary);

--- a/ueber-mich/index.html
+++ b/ueber-mich/index.html
@@ -36,6 +36,7 @@
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       background:
+        linear-gradient(rgba(238, 242, 247, 0.45), rgba(238, 242, 247, 0.45)),
         url('../images/content-bg.jpg') top center/cover no-repeat fixed,
         var(--bg-page);
       color: var(--text-primary);


### PR DESCRIPTION
## Summary
Added a semi-transparent white overlay to the background images across multiple pages to improve text readability and visual hierarchy.

## Key Changes
- Applied a `linear-gradient(rgba(238, 242, 247, 0.45), rgba(238, 242, 247, 0.45))` overlay to the body background in both `index.html` and `ueber-mich/index.html`
- The overlay uses a light blue-gray color at 45% opacity, positioned as the first layer in the background stack before the background image

## Implementation Details
- The semi-transparent gradient is layered on top of the background image using CSS multi-background syntax
- This creates a subtle lightening effect that enhances contrast between the background and foreground content
- The change is consistent across all affected pages, maintaining a unified visual design

https://claude.ai/code/session_01PBTYHuDP2KA9tifc1S5xs3