### PR TITLE
Add Der KI-Podcast to podcasts list

### DIFF
--- a/wiki/index.html
+++ b/wiki/index.html
@@ -803,6 +803,10 @@
         <strong><a href="https://t3n-meisterprompter.podigee.io/" target="_blank" rel="noopener">t3n MeisterPrompter</a></strong> -- Wöchentlicher Podcast (mittwochs), der konkrete, direkt umsetzbare Prompt-Anleitungen für den Arbeitsalltag vorstellt und einmal im Monat häufige Prompt-Fehler aufgreift.<br>
         <em>Herausgeber: t3n Magazin; Moderation: Susanne Renate Schneider &amp; Stella-Sophie Wojtczak</em>
       </li>
+      <li>
+        <strong><a href="https://podcasts.apple.com/de/podcast/der-ki-podcast/id1698961192" target="_blank" rel="noopener">Der KI-Podcast</a></strong> -- Gregor Schmalzried und Marie Kilg ordnen die neuesten Entwicklungen rund um Künstliche Intelligenz ein und erklären, was sie für unser Leben bedeuten.<br>
+        <em>Herausgeber: ARD; Moderation: Gregor Schmalzried &amp; Marie Kilg</em>
+      </li>
     </ul>
 
     <div class="highlight-box highlight-blue">


### PR DESCRIPTION
## Summary
Added a new podcast entry to the Podcasts section of the wiki index page.

## Changes
- Added "Der KI-Podcast" (ARD) to the podcasts list
  - Podcast URL: https://podcasts.apple.com/de/podcast/der-ki-podcast/id1698961192
  - Description: A podcast by Gregor Schmalzried and Marie Kilg that explains the latest developments in artificial intelligence and their implications for our lives
  - Hosts: Gregor Schmalzried & Marie Kilg

## Details
The new entry follows the existing format and structure of other podcast listings in the document, maintaining consistency with the established HTML markup and styling conventions.

https://claude.ai/code/session_016zvK7vuXANTSeAr7Z7jP5C