### PR TITLE
Update Niklas Fauteck's profile and expand expertise sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Vibecoding Academy</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230f0f1a'/%3E%3Ctext x='2' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%237c3aed'%3E%26lt;%3C/text%3E%3Ctext x='18' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%2306b6d4'%3E%26gt;%3C/text%3E%3Cpath d='M17 8 L13 17 L18 17 L15 26' stroke='url(%23g)' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0' stop-color='%23c4b5fd'/%3E%3Cstop offset='1' stop-color='%2306b6d4'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E">
-  <meta name="description" content="Vibecoding Academy – KI-gestütztes Web-Coding Workshop: von der Idee bis zum Release">
+  <meta name="description" content="Vibecoding Academy – KI-gestütztes Web-Coding: Baue deine eigene Web-App an einem Tag. Workshop von Niklas Fauteck, Experte für Digitale Transformation.">
   <meta property="og:title" content="Vibecoding Academy – Workshop">
   <meta property="og:description" content="Baue deine eigene Web-App – an einem einzigen Tag. Keine Programmierkenntnisse nötig.">
   <meta property="og:type" content="website">
@@ -701,11 +701,13 @@
           <div class="coach-avatar" aria-hidden="true">NF</div>
           <div>
             <h5 class="mb-1" style="font-weight: 700;">Niklas Fauteck</h5>
-            <p class="coach-credential">Ex-Head of Digital Transformation Kommunikation, RTL Deutschland</p>
+            <p class="coach-credential">Head of Digital Transformation Kommunikation, RTL Deutschland</p>
             <p class="mb-2" style="font-size: 0.95rem;">
-              Niklas verbindet seit über zehn Jahren Kommunikation, Technologie und digitale Transformation.
-              Mit der Vibecoding Academy gibt er dieses Wissen weiter – pragmatisch, praxisnah und
-              ohne Voraussetzung klassischer Programmierkenntnisse.
+              Niklas verbindet seit über zehn Jahren Kommunikation und Technologie – als Brückenbauer
+              zwischen Fachbereichen und IT. Bei RTL Deutschland hat er digitale Plattformen nicht nur
+              genutzt, sondern mitentwickelt und KI-gestützte Workflows eingeführt. Mit der Vibecoding
+              Academy gibt er dieses Wissen weiter – pragmatisch, praxisnah und ohne Voraussetzung
+              klassischer Programmierkenntnisse.
             </p>
             <a href="./ueber-mich/" class="text-decoration-none" style="font-size: 0.9rem; font-weight: 600;">
               Mehr erfahren <i class="fas fa-arrow-right ms-1" style="font-size: 0.75rem;"></i>
@@ -924,7 +926,7 @@
          style="display: inline-block; padding: 0.5rem 1.25rem; background: var(--success-color); color: #fff; border-radius: 6px; text-decoration: none; font-weight: 600; font-size: 0.9rem; margin-bottom: 1rem; transition: opacity 0.2s;">
         <i class="fas fa-envelope me-2"></i>ki@fauteck.eu
       </a>
-      <p class="mb-1 small" style="color: rgba(255,255,255,0.6);">Niklas Fauteck – Coach für KI-gestütztes Vibecoding</p>
+      <p class="mb-1 small" style="color: rgba(255,255,255,0.6);">Niklas Fauteck – Coach für Digitale Transformation & KI-gestütztes Vibecoding</p>
       <div class="d-flex justify-content-center gap-3">
         <a href="https://github.com/Fauteck/vibecoding-academy" target="_blank" rel="noopener">
           <i class="fab fa-github me-1"></i>GitHub

--- a/ueber-mich/index.html
+++ b/ueber-mich/index.html
@@ -371,7 +371,7 @@
           <span style="font-size: 3.5rem; font-weight: 700; color: #fff; background: linear-gradient(135deg, #5B8BD6, #3D5A8C); width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; letter-spacing: 0.05em;">NF</span>
         </div>
         <h1 class="profile-name">Niklas Fauteck</h1>
-        <p class="profile-tagline">Coach für Digitale Transformation und KI-gestütztes Vibecoding</p>
+        <p class="profile-tagline">Digitale Transformation · Projektmanagement · KI-gestütztes Vibecoding</p>
         <div class="contact-links">
           <a class="contact-link" href="https://www.linkedin.com/in/fauteck" target="_blank" rel="noopener">
             <i class="fab fa-linkedin"></i> LinkedIn
@@ -389,9 +389,9 @@
       <div class="about-card">
         <h2 class="section-title"><i class="fas fa-address-card"></i> Dein Coach</h2>
         <div class="bio-text">
-          <p>Niklas Fauteck verbindet seit über zehn Jahren Kommunikation, Technologie und digitale Transformation. Als Head of Digital Transformation Kommunikation bei RTL Deutschland verantwortete er die strategische und operative Weiterentwicklung digitaler Systeme und Prozesse – von der Konzeption zentraler Plattformen über KI-gestützte Automatisierungen bis hin zur fachlichen Steuerung von Entwicklerteams.</p>
-          <p class="mt-3">Sein Weg führte ihn vom Technikjournalismus über die Presse- und Kommunikationsarbeit hin zur Schnittstelle zwischen Business und IT, wo er komplexe Anforderungen in tragfähige digitale Lösungen übersetzt. Dabei hat er Kommunikationssysteme nicht nur genutzt, sondern aktiv mitentwickelt – darunter den Media Hub von RTL Deutschland, KI-basierte Workflows und Custom-GPT-Lösungen für redaktionelle Prozesse.</p>
-          <p class="mt-3">Aus dieser Praxis heraus entstand seine Leidenschaft fürs Vibecoding: die Fähigkeit, mit KI-Unterstützung eigene Tools und Automatisierungen zu bauen – auch ohne klassischen Entwickler-Background. Mit der Vibecoding Academy gibt Niklas dieses Wissen weiter und zeigt, wie Menschen an der Schnittstelle von Fachlichkeit und Technologie mit KI als Co-Pilot eigene digitale Lösungen umsetzen können – pragmatisch, praxisnah und mit dem Anspruch, echte Mehrwerte zu schaffen.</p>
+          <p>Niklas Fauteck verbindet seit über zehn Jahren Kommunikation, Technologie und digitale Transformation. Als Head of Digital Transformation Kommunikation bei RTL Deutschland verantwortete er die strategische und operative Weiterentwicklung digitaler Systeme und Prozesse – von der Konzeption zentraler Plattformen wie dem Media Hub, PICTRON und MDC über KI-gestützte Automatisierungen bis hin zur fachlichen Steuerung von Product Ownern und Entwicklerteams.</p>
+          <p class="mt-3">Sein Weg führte ihn vom Technikjournalismus über die Presse- und Kommunikationsarbeit und die Leitung des zentralen Newsdesk hin zur Schnittstelle zwischen Business und IT, wo er komplexe Anforderungen in tragfähige digitale Lösungen übersetzt. Dabei hat er Kommunikationssysteme nicht nur genutzt, sondern aktiv mitentwickelt – darunter den Media Hub von RTL Deutschland, KI-basierte Workflows und Custom-GPT-Lösungen für redaktionelle Prozesse.</p>
+          <p class="mt-3">Aus dieser Praxis heraus entstand seine Leidenschaft fürs Vibecoding: die Fähigkeit, mit KI-Unterstützung eigene Tools und Automatisierungen zu bauen – auch ohne klassischen Entwickler-Background. Als langjähriger Moderator von Science Slams und Live-Events weiß Niklas, wie man komplexe Inhalte verständlich und unterhaltsam vermittelt. Mit der Vibecoding Academy gibt er dieses Wissen weiter und zeigt, wie Menschen mit KI als Co-Pilot eigene digitale Lösungen umsetzen können – pragmatisch, praxisnah und mit dem Anspruch, echte Mehrwerte zu schaffen.</p>
         </div>
       </div>
 
@@ -412,6 +412,24 @@
           <div class="skill-icon"><i class="fas fa-code"></i></div>
           <h3>Vibecoding</h3>
           <p>Mit KI als Co-Pilot eigene Tools und Anwendungen bauen – pragmatisch und ohne klassischen Dev-Background</p>
+        </div>
+        <div class="skill-card">
+          <div class="skill-icon"><i class="fas fa-diagram-project"></i></div>
+          <h3>Strategisches Projektmanagement</h3>
+          <p>Planung, Steuerung und Priorisierung komplexer Digitalprojekte mit interdisziplinären Teams</p>
+        </div>
+        <div class="skill-card">
+          <div class="skill-icon"><i class="fas fa-arrows-left-right"></i></div>
+          <h3>Schnittstellenkompetenz</h3>
+          <p>Übersetzung fachlicher Anforderungen in technische Lösungen – Brückenbauer zwischen Kommunikation und IT</p>
+        </div>
+      </div>
+
+      <!-- Persönlich -->
+      <div class="about-card">
+        <h2 class="section-title"><i class="fas fa-heart"></i> Persönlich</h2>
+        <div class="bio-text">
+          <p>Abseits des Schreibtischs ist Niklas Smart-Home-Enthusiast, bastelt mit 3D-Druckern und moderierte viele Jahre Science Slams. Die Maker-Mentalität – Dinge einfach ausprobieren, iterieren und besser machen – zieht sich durch alles, was er tut.</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Updated Niklas Fauteck's professional profile across the website to better reflect his current role, expertise, and personal interests. Enhanced the "About" section with additional skill categories and a new personal section.

## Key Changes

**Profile & Bio Updates:**
- Changed tagline from "Coach für Digitale Transformation und KI-gestütztes Vibecoding" to a more comprehensive "Digitale Transformation · Projektmanagement · KI-gestütztes Vibecoding"
- Updated job title from "Ex-Head of Digital Transformation Kommunikation" to "Head of Digital Transformation Kommunikation" (removed "Ex-")
- Expanded bio paragraphs with specific platform names (Media Hub, PICTRON, MDC) and additional career details
- Added mention of Newsdesk leadership and Science Slam moderation experience

**New Expertise Sections:**
- Added "Strategisches Projektmanagement" skill card highlighting complex digital project management
- Added "Schnittstellenkompetenz" skill card emphasizing bridge-building between business and IT

**New Personal Section:**
- Created dedicated "Persönlich" (Personal) section describing hobbies and maker mentality (Smart Home, 3D printing, Science Slams)

**Meta & Footer Updates:**
- Enhanced meta description on homepage for better SEO
- Updated footer tagline to include both "Digitale Transformation" and "KI-gestütztes Vibecoding"
- Refined coach bio on homepage for clarity and better narrative flow

## Implementation Details
All changes maintain existing HTML structure and styling. Updates are purely content-focused, improving the narrative around Niklas's expertise and making his profile more comprehensive and authentic.

https://claude.ai/code/session_01B9Cgh5qJGPpQNLHcVMbazp