### PR TITLE
Add back navigation links to all pages

### DIFF
--- a/apps/gta/index.html
+++ b/apps/gta/index.html
@@ -23,6 +23,9 @@
       position: fixed; top: 0; left: 0; right: 0;
       z-index: 1030; box-shadow: 0 2px 8px rgba(0,0,0,0.12);
     }
+    .navbar-back-link { color: rgba(255,255,255,0.75); font-size: 0.85rem; text-decoration: none; transition: color 0.2s; }
+    .navbar-back-link:hover { color: #fff; }
+    .navbar-back-separator { color: rgba(255,255,255,0.3); margin: 0 0.5rem; }
     .navbar-brand { color: #fff !important; font-size: 1.3rem; font-weight: bold; }
     .navbar-link {
       color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
@@ -238,6 +241,10 @@
   <!-- Desktop Navbar (>992px) -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
+      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
+        <i class="fas fa-house me-1"></i> niklasfauteck.de
+      </a>
+      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../../">
         <i class="fas fa-code me-1"></i> Vibecoding Academy
       </a>
@@ -281,6 +288,9 @@
 
   <!-- Mobile Top Bar (<=992px) -->
   <div class="mobile-topbar d-lg-none">
+    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
+      <i class="fas fa-arrow-left"></i>
+    </a>
     <a class="mobile-topbar-brand" href="../../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>

--- a/apps/pong/index.html
+++ b/apps/pong/index.html
@@ -22,6 +22,9 @@
       position: fixed; top: 0; left: 0; right: 0;
       z-index: 1030; box-shadow: 0 2px 8px rgba(0,0,0,0.12);
     }
+    .navbar-back-link { color: rgba(255,255,255,0.75); font-size: 0.85rem; text-decoration: none; transition: color 0.2s; }
+    .navbar-back-link:hover { color: #fff; }
+    .navbar-back-separator { color: rgba(255,255,255,0.3); margin: 0 0.5rem; }
     .navbar-brand { color: #fff !important; font-size: 1.3rem; font-weight: bold; }
     .navbar-link {
       color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
@@ -92,6 +95,10 @@
   <!-- Desktop Navbar (>992px) -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
+      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
+        <i class="fas fa-house me-1"></i> niklasfauteck.de
+      </a>
+      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../../">
         <i class="fas fa-code me-1"></i> Vibecoding Academy
       </a>
@@ -135,6 +142,9 @@
 
   <!-- Mobile Top Bar (<=992px) -->
   <div class="mobile-topbar d-lg-none">
+    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
+      <i class="fas fa-arrow-left"></i>
+    </a>
     <a class="mobile-topbar-brand" href="../../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>

--- a/apps/wochenendplanung/index.html
+++ b/apps/wochenendplanung/index.html
@@ -49,6 +49,9 @@
       position: fixed; top: 0; left: 0; right: 0;
       z-index: 1030; box-shadow: 0 2px 8px rgba(0,0,0,0.12);
     }
+    .navbar-back-link { color: rgba(255,255,255,0.75); font-size: 0.85rem; text-decoration: none; transition: color 0.2s; }
+    .navbar-back-link:hover { color: #fff; }
+    .navbar-back-separator { color: rgba(255,255,255,0.3); margin: 0 0.5rem; }
     .navbar-brand { color: #fff !important; font-size: 1.3rem; font-weight: bold; }
     .navbar-link {
       color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
@@ -225,6 +228,10 @@
   <!-- Desktop Navbar (>992px) -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
+      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
+        <i class="fas fa-house me-1"></i> niklasfauteck.de
+      </a>
+      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../../">
         <i class="fas fa-code me-1"></i> Vibecoding Academy
       </a>
@@ -268,6 +275,9 @@
 
   <!-- Mobile Top Bar (<=992px) -->
   <div class="mobile-topbar d-lg-none">
+    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
+      <i class="fas fa-arrow-left"></i>
+    </a>
     <a class="mobile-topbar-brand" href="../../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>

--- a/index.html
+++ b/index.html
@@ -67,6 +67,22 @@
       box-shadow: 0 2px 8px rgba(0,0,0,0.12);
     }
 
+    .navbar-back-link {
+      color: rgba(255,255,255,0.75);
+      font-size: 0.85rem;
+      text-decoration: none;
+      transition: color 0.2s;
+    }
+
+    .navbar-back-link:hover {
+      color: #fff;
+    }
+
+    .navbar-back-separator {
+      color: rgba(255,255,255,0.3);
+      margin: 0 0.5rem;
+    }
+
     .navbar-brand {
       color: #fff !important;
       font-size: 1.3rem;
@@ -469,6 +485,10 @@
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
+      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
+        <i class="fas fa-house me-1"></i> niklasfauteck.de
+      </a>
+      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="#">
         <i class="fas fa-code me-1"></i> Vibecoding Academy
       </a>
@@ -514,6 +534,9 @@
   <!--  Mobile Top Bar (<=992px)                             -->
   <!-- ══════════════════════════════════════════════════════ -->
   <div class="mobile-topbar d-lg-none">
+    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
+      <i class="fas fa-arrow-left"></i>
+    </a>
     <span class="mobile-topbar-brand">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </span>

--- a/ueber-mich/index.html
+++ b/ueber-mich/index.html
@@ -49,6 +49,9 @@
       position: fixed; top: 0; left: 0; right: 0;
       z-index: 1030; box-shadow: 0 2px 8px rgba(0,0,0,0.12);
     }
+    .navbar-back-link { color: rgba(255,255,255,0.75); font-size: 0.85rem; text-decoration: none; transition: color 0.2s; }
+    .navbar-back-link:hover { color: #fff; }
+    .navbar-back-separator { color: rgba(255,255,255,0.3); margin: 0 0.5rem; }
     .navbar-brand { color: #fff !important; font-size: 1.3rem; font-weight: bold; }
     .navbar-link {
       color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
@@ -263,6 +266,10 @@
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
+      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
+        <i class="fas fa-house me-1"></i> niklasfauteck.de
+      </a>
+      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../">
         <i class="fas fa-code me-1"></i> Vibecoding Academy
       </a>
@@ -308,6 +315,9 @@
   <!--  Mobile Top Bar (<=992px)                             -->
   <!-- ══════════════════════════════════════════════════════ -->
   <div class="mobile-topbar d-lg-none">
+    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
+      <i class="fas fa-arrow-left"></i>
+    </a>
     <a class="mobile-topbar-brand" href="../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -23,6 +23,9 @@
       position: fixed; top: 0; left: 0; right: 0;
       z-index: 1030; box-shadow: 0 2px 8px rgba(0,0,0,0.12);
     }
+    .navbar-back-link { color: rgba(255,255,255,0.75); font-size: 0.85rem; text-decoration: none; transition: color 0.2s; }
+    .navbar-back-link:hover { color: #fff; }
+    .navbar-back-separator { color: rgba(255,255,255,0.3); margin: 0 0.5rem; }
     .navbar-brand { color: #fff !important; font-size: 1.3rem; font-weight: bold; }
     .navbar-link {
       color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
@@ -124,6 +127,10 @@
   <!-- Desktop Navbar (>992px) -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
+      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
+        <i class="fas fa-house me-1"></i> niklasfauteck.de
+      </a>
+      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../">
         <i class="fas fa-code me-1"></i> Vibecoding Academy
       </a>
@@ -167,6 +174,9 @@
 
   <!-- Mobile Top Bar (<=992px) -->
   <div class="mobile-topbar d-lg-none">
+    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
+      <i class="fas fa-arrow-left"></i>
+    </a>
     <a class="mobile-topbar-brand" href="../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>


### PR DESCRIPTION
## Summary
Added navigation links to return to the main website (niklasfauteck.de) across all pages in the Vibecoding Academy section. This improves navigation flow by allowing users to easily return to the parent website from any subpage.

## Key Changes
- **New CSS styles** for back navigation elements:
  - `.navbar-back-link`: Styled link with hover effect for desktop navigation
  - `.navbar-back-separator`: Visual separator between back link and brand name
  
- **Desktop navbar updates**: Added a back link with house icon and "niklasfauteck.de" text to the left of the brand name on all pages:
  - index.html (main page)
  - ueber-mich/index.html
  - wiki/index.html
  - apps/gta/index.html
  - apps/pong/index.html
  - apps/wochenendplanung/index.html

- **Mobile topbar updates**: Added a back button with left arrow icon to the mobile navigation on all pages for consistency

## Implementation Details
- Back links point to `https://fauteck.github.io/website/` with appropriate relative paths for subpages
- Includes proper ARIA labels in German ("Zurück zu niklasfauteck.de") for accessibility
- Uses Font Awesome icons (house for desktop, arrow-left for mobile)
- Maintains consistent styling with semi-transparent white text that becomes fully opaque on hover
- Mobile back button uses the existing `mobile-topbar-btn` class for consistent styling

https://claude.ai/code/session_01S31xHH2ZSmU17e2FaZzMxv