### PR TITLE
Reorganize idea/concept files from ideen/ to projekte/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ vibecoding-academy/
 
 ### Spielkonzepte
 
-Konzepte und Spielideen als Markdown-Dateien in `ideen/`, abrufbar über den [Konzept-Viewer](https://fauteck.github.io/vibecoding-academy/ideen/viewer.html):
+Konzepte und Spielideen als Markdown-Dateien in `projekte/`, abrufbar über den [Konzept-Viewer](https://fauteck.github.io/vibecoding-academy/projekte/viewer.html):
 
 Flappy Bird, Haushaltsbuch, Memory, Minesweeper, Pong, Snake, Solitär, Sudoku, Tetris, Tic-Tac-Toe
 

--- a/projekte/index.html
+++ b/projekte/index.html
@@ -264,7 +264,7 @@
 
     <div class="row g-3 mb-4">
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=flappybird.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=flappybird.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">🐦</div>
             <h6 class="card-title">Flappy Bird</h6>
@@ -273,7 +273,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=memory.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=memory.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">🃏</div>
             <h6 class="card-title">Memory</h6>
@@ -282,7 +282,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=minesweeper.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=minesweeper.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">💣</div>
             <h6 class="card-title">Minesweeper</h6>
@@ -291,7 +291,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=pong.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=pong.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">🏓</div>
             <h6 class="card-title">Pong</h6>
@@ -300,7 +300,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=snake.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=snake.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">🐍</div>
             <h6 class="card-title">Snake</h6>
@@ -309,7 +309,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=solitaire.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=solitaire.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">🂡</div>
             <h6 class="card-title">Solitär</h6>
@@ -318,7 +318,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=sudoku.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=sudoku.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">🔢</div>
             <h6 class="card-title">Sudoku</h6>
@@ -327,7 +327,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=tetris.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=tetris.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">🧱</div>
             <h6 class="card-title">Tetris</h6>
@@ -336,7 +336,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=tictactoe.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=tictactoe.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">❌</div>
             <h6 class="card-title">Tic-Tac-Toe</h6>
@@ -345,7 +345,7 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <a class="card text-decoration-none h-100" href="../ideen/viewer.html?file=haushaltsbuch.md">
+        <a class="card text-decoration-none h-100" href="viewer.html?file=haushaltsbuch.md">
           <div class="card-body text-center">
             <div class="fs-1 mb-2">📒</div>
             <h6 class="card-title">Haushaltsbuch</h6>

--- a/projekte/viewer.html
+++ b/projekte/viewer.html
@@ -8,7 +8,7 @@
   <meta property="og:title" content="Spielideen - Vibecoding Academy">
   <meta property="og:description" content="Spielkonzepte und Ideen für den Vibecoding-Workshop – von Flappy Bird bis Tetris.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://fauteck.github.io/vibecoding-academy/ideen/viewer.html">
+  <meta property="og:url" content="https://fauteck.github.io/vibecoding-academy/projekte/viewer.html">
   <meta property="og:locale" content="de_DE">
   <meta name="theme-color" content="#5B8BD6">
   <link rel="stylesheet"

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -21,7 +21,7 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://fauteck.github.io/vibecoding-academy/ideen/viewer.html</loc>
+    <loc>https://fauteck.github.io/vibecoding-academy/projekte/viewer.html</loc>
     <priority>0.6</priority>
   </url>
   <url>


### PR DESCRIPTION
## Summary
This PR relocates the game concept and idea files from the `ideen/` directory to the `projekte/` directory, updating all references throughout the codebase to reflect the new location.

## Key Changes
- **Updated relative links in `projekte/index.html`**: Changed all 11 game concept links from `../ideen/viewer.html?file=...` to `viewer.html?file=...` (Flappy Bird, Memory, Minesweeper, Pong, Snake, Solitär, Sudoku, Tetris, Tic-Tac-Toe, and Haushaltsbuch)
- **Updated documentation in `README.md`**: Changed reference from `ideen/` to `projekte/` directory and updated the Concept-Viewer URL accordingly
- **Updated Open Graph metadata in `projekte/viewer.html`**: Changed the `og:url` property from `ideen/viewer.html` to `projekte/viewer.html`
- **Updated sitemap in `sitemap.xml`**: Changed the URL entry for the concept viewer from `ideen/viewer.html` to `projekte/viewer.html`

## Implementation Details
All changes maintain the same functionality while consolidating the project structure. The viewer.html file is now accessed directly from the `projekte/` directory, simplifying the URL structure and improving the organization of project-related content.

https://claude.ai/code/session_0195XGX6rrAA43uaGmP9YL7Z