### PR TITLE
Add duplicate navigation bar at top of idea viewer

### DIFF
--- a/projekte/viewer.html
+++ b/projekte/viewer.html
@@ -43,6 +43,7 @@
     .loading { text-align: center; padding: 3rem; color: #888; font-size: 1.1rem; }
     .error { text-align: center; padding: 3rem; color: #e74c3c; }
     .idea-nav { max-width: 800px; margin: 1rem auto 2rem; padding: 0 2rem; display: flex; justify-content: space-between; align-items: center; gap: 1rem; }
+    .idea-nav-top { margin: 2rem auto 0; }
     .idea-nav a { display: inline-flex; align-items: center; gap: 0.4rem; color: #3498db; text-decoration: none; font-size: 0.9rem; padding: 0.4rem 0.8rem; border-radius: 6px; border: 1px solid #dde; transition: background 0.2s; }
     .idea-nav a:hover { background: #eef3f8; }
     .idea-nav .disabled { pointer-events: none; opacity: 0.3; }
@@ -103,6 +104,7 @@
       <span>Coach</span>
     </a>
   </nav>
+  <nav id="idea-nav-top" class="idea-nav idea-nav-top" style="display:none;"></nav>
   <div id="content"><div class="loading">Laden...</div></div>
   <nav id="idea-nav" class="idea-nav" style="display:none;"></nav>
   <script src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js"
@@ -135,6 +137,7 @@
       var idx = ideas.findIndex(function(i) { return i.file === file; });
       if (idx !== -1) {
         var nav = document.getElementById('idea-nav');
+        var navTop = document.getElementById('idea-nav-top');
         var prev = idx > 0 ? ideas[idx - 1] : null;
         var next = idx < ideas.length - 1 ? ideas[idx + 1] : null;
 
@@ -152,6 +155,8 @@
         }
         nav.innerHTML = html;
         nav.style.display = 'flex';
+        navTop.innerHTML = html;
+        navTop.style.display = 'flex';
       }
 
       fetch(file)


### PR DESCRIPTION
## Summary
This change adds a duplicate navigation bar positioned at the top of the idea viewer content, allowing users to navigate between ideas without scrolling to the bottom of the page.

## Key Changes
- Added new `.idea-nav-top` CSS class with top margin positioning to distinguish it from the bottom navigation bar
- Added a new `<nav id="idea-nav-top">` element positioned above the main content area
- Updated the JavaScript logic to populate both the bottom navigation (`#idea-nav`) and the new top navigation (`#idea-nav-top`) with identical HTML content
- Both navigation bars are shown/hidden together and display the same previous/next navigation links

## Implementation Details
- The top navigation bar is initially hidden with `display:none` and only shown when idea content is loaded
- Both navigation bars share the same styling classes (`idea-nav` and `idea-nav-top`) for consistency
- The navigation HTML is generated once and duplicated to both elements, ensuring they stay synchronized

https://claude.ai/code/session_01T6AyoeUYkXETmJfwCr8Tx1