### PR TITLE
Refactor navigation: remove back link and GitHub link, enhance branding

### DIFF
--- a/agb.html
+++ b/agb.html
@@ -99,15 +99,12 @@
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="./">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="./#workshop">Workshop</a>
+        <a class="navbar-link" href="./">Workshop</a>
         <a class="navbar-link" href="./wiki/">Wiki</a>
         <a class="navbar-link" href="./projekte/">Projekte</a>
         <a class="navbar-link" href="./ueber-mich/">Coach</a>
@@ -119,13 +116,9 @@
   <!--  Mobile Top Bar (<=992px)                             -->
   <!-- ══════════════════════════════════════════════════════ -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="./">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
   <!-- ══════════════════════════════════════════════════════ -->
@@ -339,7 +332,7 @@
   <!--  Mobile Bottom Navigation (<=992px)                   -->
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="./#workshop">
+    <a class="bottom-nav-item" href="./">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/apps/gta/index.html
+++ b/apps/gta/index.html
@@ -228,15 +228,12 @@
   <!-- Desktop Navbar (>992px) -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../../#workshop">Workshop</a>
+        <a class="navbar-link" href="../../">Workshop</a>
         <a class="navbar-link" href="../../wiki/">Wiki</a>
         <a class="navbar-link active" href="../../projekte/">Projekte</a>
         <a class="navbar-link" href="../../ueber-mich/">Coach</a>
@@ -246,18 +243,14 @@
 
   <!-- Mobile Top Bar (<=992px) -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="../../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
   <!-- Mobile Bottom Navigation (<=992px) -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../../#workshop">
+    <a class="bottom-nav-item" href="../../">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/apps/pong/index.html
+++ b/apps/pong/index.html
@@ -76,15 +76,12 @@
   <!-- Desktop Navbar (>992px) -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../../#workshop">Workshop</a>
+        <a class="navbar-link" href="../../">Workshop</a>
         <a class="navbar-link" href="../../wiki/">Wiki</a>
         <a class="navbar-link active" href="../../projekte/">Projekte</a>
         <a class="navbar-link" href="../../ueber-mich/">Coach</a>
@@ -94,18 +91,14 @@
 
   <!-- Mobile Top Bar (<=992px) -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="../../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
   <!-- Mobile Bottom Navigation (<=992px) -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../../#workshop">
+    <a class="bottom-nav-item" href="../../">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/apps/wochenendplanung/index.html
+++ b/apps/wochenendplanung/index.html
@@ -172,15 +172,12 @@
   <!-- Desktop Navbar (>992px) -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../../#workshop">Workshop</a>
+        <a class="navbar-link" href="../../">Workshop</a>
         <a class="navbar-link" href="../../wiki/">Wiki</a>
         <a class="navbar-link active" href="../../projekte/">Projekte</a>
         <a class="navbar-link" href="../../ueber-mich/">Coach</a>
@@ -190,18 +187,14 @@
 
   <!-- Mobile Top Bar (<=992px) -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="../../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
   <!-- Mobile Bottom Navigation (<=992px) -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../../#workshop">
+    <a class="bottom-nav-item" href="../../">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/css/nav.css
+++ b/css/nav.css
@@ -4,7 +4,16 @@
   position: fixed; top: 0; left: 0; right: 0;
   z-index: 1030; box-shadow: 0 2px 8px rgba(0,0,0,0.12);
 }
-.navbar-brand { color: #fff !important; font-size: 1.3rem; font-weight: bold; }
+.navbar .container-fluid { justify-content: space-between; }
+.navbar-brand {
+  color: #fff !important; text-decoration: none;
+  display: flex; flex-direction: column; gap: 0.1rem; line-height: 1.2;
+}
+.navbar-brand-name { font-size: 1.3rem; font-weight: bold; }
+.navbar-brand-subtitle {
+  font-size: 0.7rem; font-weight: 400; color: rgba(255,255,255,0.7);
+  letter-spacing: 0.05em; text-transform: uppercase;
+}
 .navbar-link {
   color: rgba(255,255,255,0.75); text-decoration: none; font-size: 0.875rem;
   padding: 0.4rem 0.8rem; border-radius: 6px; transition: background 0.2s, color 0.2s;

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -99,15 +99,12 @@
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="./">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="./#workshop">Workshop</a>
+        <a class="navbar-link" href="./">Workshop</a>
         <a class="navbar-link" href="./wiki/">Wiki</a>
         <a class="navbar-link" href="./projekte/">Projekte</a>
         <a class="navbar-link" href="./ueber-mich/">Coach</a>
@@ -119,13 +116,9 @@
   <!--  Mobile Top Bar (<=992px)                             -->
   <!-- ══════════════════════════════════════════════════════ -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="./">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
   <!-- ══════════════════════════════════════════════════════ -->
@@ -325,7 +318,7 @@
   <!--  Mobile Bottom Navigation (<=992px)                   -->
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="./#workshop">
+    <a class="bottom-nav-item" href="./">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/hosting/index.html
+++ b/hosting/index.html
@@ -148,18 +148,15 @@
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../#workshop">Workshop</a>
+        <a class="navbar-link" href="../">Workshop</a>
+        <a class="navbar-link" href="../wiki/">Wiki</a>
         <a class="navbar-link" href="../projekte/">Projekte</a>
         <a class="navbar-link" href="../ueber-mich/">Coach</a>
-        <a class="navbar-link" href="../wiki/">Wiki</a>
       </div>
     </div>
   </nav>
@@ -168,13 +165,9 @@
   <!--  Mobile Top Bar (<=992px)                             -->
   <!-- ══════════════════════════════════════════════════════ -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
 
@@ -182,7 +175,7 @@
   <!--  Mobile Bottom Navigation (<=992px)                   -->
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../#workshop">
+    <a class="bottom-nav-item" href="../">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/impressum.html
+++ b/impressum.html
@@ -99,15 +99,12 @@
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="./">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="./#workshop">Workshop</a>
+        <a class="navbar-link" href="./">Workshop</a>
         <a class="navbar-link" href="./wiki/">Wiki</a>
         <a class="navbar-link" href="./projekte/">Projekte</a>
         <a class="navbar-link" href="./ueber-mich/">Coach</a>
@@ -119,13 +116,9 @@
   <!--  Mobile Top Bar (<=992px)                             -->
   <!-- ══════════════════════════════════════════════════════ -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="./">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
 
@@ -276,7 +269,7 @@
   <!--  Mobile Bottom Navigation (<=992px)                   -->
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="./#workshop">
+    <a class="bottom-nav-item" href="./">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/index.html
+++ b/index.html
@@ -485,33 +485,23 @@
 
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
-      <a class="navbar-brand" href="#">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+      <a class="navbar-brand" href="./">
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link active" href="#workshop">Workshop</a>
+        <a class="navbar-link active" href="./">Workshop</a>
         <a class="navbar-link" href="./wiki/">Wiki</a>
         <a class="navbar-link" href="./projekte/">Projekte</a>
         <a class="navbar-link" href="./ueber-mich/">Coach</a>
-        <a class="navbar-link" href="https://github.com/Fauteck/vibecoding-academy" target="_blank" rel="noopener">
-          <i class="fab fa-github me-1"></i> GitHub
-        </a>
       </div>
     </div>
   </nav>
 
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
-    <span class="mobile-topbar-brand">
+    <a class="mobile-topbar-brand" href="./">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
-    </span>
-    <span style="width: 32px;"></span>
+    </a>
   </div>
 
   <div class="hero-section">
@@ -858,7 +848,7 @@
   </footer>
 
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item active" href="#workshop">
+    <a class="bottom-nav-item active" href="./">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/kontakt/index.html
+++ b/kontakt/index.html
@@ -157,19 +157,15 @@
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../#workshop">Workshop</a>
+        <a class="navbar-link" href="../">Workshop</a>
         <a class="navbar-link" href="../wiki/">Wiki</a>
         <a class="navbar-link" href="../projekte/">Projekte</a>
         <a class="navbar-link" href="../ueber-mich/">Coach</a>
-        <a class="navbar-link active" href="../kontakt/">Kontakt</a>
       </div>
     </div>
   </nav>
@@ -178,13 +174,9 @@
   <!--  Mobile Top Bar (<=992px)                             -->
   <!-- ══════════════════════════════════════════════════════ -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
   <!-- ══════════════════════════════════════════════════════ -->
@@ -268,7 +260,7 @@
   <!--  Mobile Bottom Navigation (<=992px)                   -->
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../#workshop">
+    <a class="bottom-nav-item" href="../">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/projekte/index.html
+++ b/projekte/index.html
@@ -162,21 +162,15 @@
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../#workshop">Workshop</a>
+        <a class="navbar-link" href="../">Workshop</a>
         <a class="navbar-link" href="../wiki/">Wiki</a>
         <a class="navbar-link active" href="../projekte/">Projekte</a>
         <a class="navbar-link" href="../ueber-mich/">Coach</a>
-        <a class="navbar-link" href="https://github.com/Fauteck/vibecoding-academy" target="_blank" rel="noopener">
-          <i class="fab fa-github me-1"></i> GitHub
-        </a>
       </div>
     </div>
   </nav>
@@ -185,15 +179,8 @@
   <!--  Mobile Top Bar (<=992px)                             -->
   <!-- ══════════════════════════════════════════════════════ -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
-    </a>
-    <a href="https://github.com/Fauteck/vibecoding-academy"
-       class="mobile-topbar-btn" target="_blank" rel="noopener" aria-label="GitHub">
-      <i class="fab fa-github"></i>
     </a>
   </div>
 
@@ -382,7 +369,7 @@
   <!--  Mobile Bottom Navigation (<=992px)                   -->
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../#workshop">
+    <a class="bottom-nav-item" href="../">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/projekte/viewer.html
+++ b/projekte/viewer.html
@@ -58,15 +58,12 @@
   <!-- Desktop Navbar (>992px) -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../#workshop">Workshop</a>
+        <a class="navbar-link" href="../">Workshop</a>
         <a class="navbar-link" href="../wiki/">Wiki</a>
         <a class="navbar-link" href="../projekte/">Projekte</a>
         <a class="navbar-link" href="../ueber-mich/">Coach</a>
@@ -76,18 +73,14 @@
 
   <!-- Mobile Top Bar (<=992px) -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
   <!-- Mobile Bottom Navigation (<=992px) -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../#workshop">
+    <a class="bottom-nav-item" href="../">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/ueber-mich/index.html
+++ b/ueber-mich/index.html
@@ -209,15 +209,12 @@
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../#workshop">Workshop</a>
+        <a class="navbar-link" href="../">Workshop</a>
         <a class="navbar-link" href="../wiki/">Wiki</a>
         <a class="navbar-link" href="../projekte/">Projekte</a>
         <a class="navbar-link active" href="../ueber-mich/">Coach</a>
@@ -229,13 +226,9 @@
   <!--  Mobile Top Bar (<=992px)                             -->
   <!-- ══════════════════════════════════════════════════════ -->
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
   <!-- ══════════════════════════════════════════════════════ -->
@@ -340,7 +333,7 @@
   <!--  Mobile Bottom Navigation (<=992px)                   -->
   <!-- ══════════════════════════════════════════════════════ -->
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../#workshop">
+    <a class="bottom-nav-item" href="../">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -563,37 +563,27 @@
 
   <nav class="navbar navbar-expand d-none d-lg-flex">
     <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
       <a class="navbar-brand" href="../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
+        <span class="navbar-brand-name"><i class="fas fa-code me-1"></i> Vibecoding Academy</span>
+        <span class="navbar-brand-subtitle">mit Niklas Fauteck</span>
       </a>
       <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../#workshop">Workshop</a>
+        <a class="navbar-link" href="../">Workshop</a>
         <a class="navbar-link active" href="../wiki/">Wiki</a>
         <a class="navbar-link" href="../projekte/">Projekte</a>
         <a class="navbar-link" href="../ueber-mich/">Coach</a>
-        <a class="navbar-link" href="https://github.com/Fauteck/vibecoding-academy" target="_blank" rel="noopener">
-          <i class="fab fa-github me-1"></i> GitHub
-        </a>
       </div>
     </div>
   </nav>
 
   <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
     <a class="mobile-topbar-brand" href="../">
       <i class="fas fa-code me-1"></i> Vibecoding Academy
     </a>
-    <span style="width: 32px;"></span>
   </div>
 
   <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../#workshop">
+    <a class="bottom-nav-item" href="../">
       <i class="fas fa-chalkboard-user"></i>
       <span>Workshop</span>
     </a>


### PR DESCRIPTION
## Summary
This PR refactors the navigation structure across all pages by removing the back link to the external portfolio site and GitHub link, while enhancing the navbar branding with a subtitle. The changes simplify navigation and make the Vibecoding Academy a more standalone experience.

## Key Changes
- **Removed external navigation elements**: Eliminated the "niklasfauteck.de" back link and separator from all navbar instances across the site
- **Removed GitHub link**: Deleted the GitHub repository link from desktop and mobile navigation menus
- **Enhanced navbar branding**: Updated the navbar brand to display as a flex column with:
  - Main brand name: "Vibecoding Academy" (1.3rem, bold)
  - Subtitle: "mit Niklas Fauteck" (0.7rem, uppercase, reduced opacity)
- **Fixed navigation links**: Changed anchor links from `#workshop` to `./` or `../` to properly navigate to the home page instead of a section anchor
- **Cleaned up mobile topbar**: Removed the back button and placeholder spacing elements from mobile navigation
- **Updated CSS**: Added styling for the new navbar brand structure with proper flexbox layout and typography for the subtitle

## Implementation Details
- Applied changes consistently across all HTML files (index.html, wiki, projekte, ueber-mich, kontakt, hosting, agb, datenschutz, impressum, and app pages)
- The navbar brand now uses semantic HTML with span elements for name and subtitle
- Navigation links now use relative paths (`./` or `../`) instead of anchor fragments for better navigation semantics
- CSS updates maintain responsive design while supporting the new multi-line brand display

https://claude.ai/code/session_01U2o3aHcfDFe2D1wkJbaZp4