### PR TITLE
Add website link to contact information

### DIFF
--- a/kontakt/index.html
+++ b/kontakt/index.html
@@ -237,6 +237,14 @@
             <a href="mailto:me@fauteck.eu">me@fauteck.eu</a>
           </div>
         </div>
+
+        <div class="contact-card">
+          <div class="card-icon"><i class="fas fa-globe"></i></div>
+          <div class="card-title">Website</div>
+          <div class="card-value">
+            <a href="https://fauteck.github.io/website" target="_blank" rel="noopener">fauteck.github.io/website</a>
+          </div>
+        </div>
       </div>
 
       <a href="mailto:me@fauteck.eu?subject=Kontaktanfrage" class="cta-btn">

--- a/ueber-mich/index.html
+++ b/ueber-mich/index.html
@@ -252,6 +252,9 @@
           <a class="contact-link" href="https://github.com/Fauteck" target="_blank" rel="noopener">
             <i class="fab fa-github"></i> GitHub
           </a>
+          <a class="contact-link" href="https://fauteck.github.io/website" target="_blank" rel="noopener">
+            <i class="fas fa-globe"></i> Website
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Added a new website link to the contact information sections across multiple pages to improve accessibility to the personal website.

## Key Changes
- **kontakt/index.html**: Added a new contact card displaying the website link (fauteck.github.io/website) with a globe icon, matching the existing contact card styling for email
- **ueber-mich/index.html**: Added a website link in the contact links section alongside the existing GitHub link with a globe icon

## Implementation Details
- The website link opens in a new tab with `target="_blank"` and includes `rel="noopener"` for security best practices
- Consistent styling and icon usage (Font Awesome globe icon) across both pages
- The link follows the same pattern as existing contact methods for visual and functional consistency

https://claude.ai/code/session_014HhJHcam2rKy3UfXCcqdTH