### PR TITLE
Hero-Text schärfen und Angebotsbox ergänzen

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,31 +503,57 @@
     <div class="hero-inner">
       <span class="badge hero-badge mb-3">Praxisnaher Workshop</span>
 
-      <h1>Baue mit KI funktionierende Prototypen</h1>
+      <h1>Mit KI von der Idee zum klickbaren Prototypen</h1>
 
       <p class="hero-lead mx-auto mt-3 mb-0">
-        Praxisnaher Workshop für kleine Web-Apps, interne Tools und erste Produktideen –
-        auch ohne tiefe Programmiererfahrung.
+        Ein kompakter Workshop für Produktmenschen, Projektverantwortliche und Innovationsteams,
+        die aus einer Idee schnell etwas Nutzbares machen wollen: einen testbaren Prototypen
+        oder ein erstes internes Tool – auch ohne tiefe Coding-Erfahrung.
       </p>
-
-      <div class="hero-kpis">
-        <div class="hero-kpi">Praxis statt Theorie</div>
-        <div class="hero-kpi">Auch ohne Coding-Erfahrung</div>
-        <div class="hero-kpi">Mit Ergebnis nach Hause</div>
-      </div>
 
       <div class="hero-actions">
         <a href="mailto:ki@fauteck.eu?subject=Workshop-Anfrage" class="hero-cta">
-          <i class="fas fa-envelope me-2"></i>Jetzt Workshop anfragen
+          <i class="fas fa-envelope me-2"></i>Workshop anfragen
         </a>
         <a href="#workshop" class="hero-link">
-          Mehr erfahren <i class="fas fa-arrow-down ms-1"></i>
+          So läuft der Workshop ab <i class="fas fa-arrow-down ms-1"></i>
         </a>
       </div>
     </div>
   </div>
 
   <main class="container-fluid py-3" style="max-width: 920px; margin: 0 auto;">
+
+    <div class="overview-box" id="angebot">
+      <h2><i class="fas fa-binoculars me-2"></i>Der Workshop auf einen Blick</h2>
+      <p class="subtle-note mt-0 mb-3">Klarer Rahmen, konkretes Ergebnis, direkt anwendbar im Arbeitsalltag.</p>
+      <ul class="overview-list">
+        <li>
+          <strong>Format</strong><br>
+          Kompakter Workshop für Teams oder Einzelpersonen, remote oder vor Ort.
+        </li>
+        <li>
+          <strong>Dauer</strong><br>
+          Je nach Zielsetzung als fokussiertes Kurzformat oder als intensiver Halbtages- bzw. Tagesworkshop.
+        </li>
+        <li>
+          <strong>Zielgruppe</strong><br>
+          Für Produktmenschen, Projektverantwortliche, Innovationsverantwortliche und Fachbereiche, die Ideen schnell greifbar machen wollen.
+        </li>
+        <li>
+          <strong>Teilnehmerzahl</strong><br>
+          Geeignet für Einzelpersonen, kleine Teams und interdisziplinäre Gruppen.
+        </li>
+        <li>
+          <strong>Ergebnis</strong><br>
+          Am Ende steht ein testbarer Prototyp oder ein erstes internes Tool, das du zeigen, besprechen und weiterentwickeln kannst.
+        </li>
+        <li>
+          <strong>Anfrageprozess</strong><br>
+          Du schilderst kurz deinen Kontext und dein Ziel. Danach klären wir Format, Teilnehmerkreis und Schwerpunkt des Workshops und du erhältst ein passendes Angebot.
+        </li>
+      </ul>
+    </div>
 
     <div class="overview-box" id="workshop">
       <h2><i class="fas fa-compass me-2"></i>Im Überblick</h2>


### PR DESCRIPTION
Hero: Neue Headline, präziserer Lead-Text, KPI-Pills entfernt,
Button- und Link-Text aktualisiert. Neue Angebotsbox "Der Workshop
auf einen Blick" mit 6 Kategorien (Format, Dauer, Zielgruppe,
Teilnehmerzahl, Ergebnis, Anfrageprozess) vor dem bestehenden
Überblick eingefügt.

https://claude.ai/code/session_01BEjkqgfavDqwobnGTGKyfc