### PR TITLE
Zielgruppen-Karten schärfen: konkrete Use Cases statt generische Rollen

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,24 +594,35 @@
 
             <p class="mb-2" style="font-weight: 700;">Besonders passend für:</p>
             <div class="row g-3 audience-grid">
-              <div class="col-md-4">
+              <div class="col-md-6">
                 <div class="card">
                   <div class="card-body">
-                    <strong><i class="fas fa-layer-group audience-icon"></i>Produktmenschen</strong>
+                    <strong><i class="fas fa-layer-group audience-icon"></i>Produktmanager</strong><br>
+                    <small class="text-muted">Ideen vor Entwicklung validieren</small>
                   </div>
                 </div>
               </div>
-              <div class="col-md-4">
+              <div class="col-md-6">
                 <div class="card">
                   <div class="card-body">
-                    <strong><i class="fas fa-diagram-project audience-icon"></i>Projektverantwortliche</strong>
+                    <strong><i class="fas fa-comments audience-icon"></i>Kommunikation</strong><br>
+                    <small class="text-muted">Kleine interne Tools ohne IT-Ticket bauen</small>
                   </div>
                 </div>
               </div>
-              <div class="col-md-4">
+              <div class="col-md-6">
                 <div class="card">
                   <div class="card-body">
-                    <strong><i class="fas fa-lightbulb audience-icon"></i>Innovationsteams</strong>
+                    <strong><i class="fas fa-lightbulb audience-icon"></i>Innovationsverantwortliche</strong><br>
+                    <small class="text-muted">Workshops mit sichtbarem Outcome statt Post-it-Runden</small>
+                  </div>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="card">
+                  <div class="card-body">
+                    <strong><i class="fas fa-diagram-project audience-icon"></i>Fachbereiche</strong><br>
+                    <small class="text-muted">Prototypen für Abstimmungen mit IT erzeugen</small>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Ersetzt die 3 breiten Zielgruppen (Produktmenschen, Projektverantwortliche,
Innovationsteams) durch 4 spezifische Use-Case-Karten mit Rolle + Nutzen
im 2x2-Raster.

https://claude.ai/code/session_01KU2Zss7Hjnoay7H3ajt43W