### PR TITLE
Startseite straffen: Redundanzen in Texten reduzieren

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,24 +555,7 @@
       </ul>
     </div>
 
-    <div class="overview-box" id="workshop">
-      <h2><i class="fas fa-compass me-2"></i>Im Überblick</h2>
-      <ul class="overview-list">
-        <li>
-          <strong>Für wen?</strong><br>
-          Für Produktmenschen, Projektverantwortliche und Teams, die Ideen schneller greifbar machen wollen.
-        </li>
-        <li>
-          <strong>Was ist das Ergebnis?</strong><br>
-          Ein klickbarer Prototyp oder ein erstes internes Tool, das du zeigen und testen kannst.
-        </li>
-        <li>
-          <strong>Wie läuft es ab?</strong><br>
-          Du arbeitest dich von einer ersten Idee über den Bau bis zu Feedback, Korrekturen und einer brauchbaren ersten Version vor.
-        </li>
-      </ul>
-    </div>
-
+    <div id="workshop"></div>
     <div class="accordion custom-accordion mb-4" id="workshopAccordion">
 
       <div class="accordion-item">
@@ -628,9 +611,6 @@
               </div>
             </div>
 
-            <p class="subtle-note mt-3 mb-0">
-              Besonders wertvoll ist der Workshop für alle, die Ideen nicht mehr nur besprechen, sondern als funktionierenden Prototypen zeigen wollen.
-            </p>
           </div>
         </div>
       </div>
@@ -676,9 +656,6 @@
               </div>
             </div>
 
-            <p class="subtle-note mt-3 mb-0">
-              Du lernst einen klaren Ablauf, mit dem du schneller von der Idee zu einem sichtbaren Ergebnis kommst.
-            </p>
           </div>
         </div>
       </div>
@@ -698,9 +675,6 @@
               <li>eine testbare Produktidee</li>
               <li>einen wiederverwendbaren Workflow für neue Ideen</li>
             </ul>
-            <p class="mb-0">
-              So kannst du danach nicht nur besser über Ideen sprechen – du kannst etwas zeigen.
-            </p>
           </div>
         </div>
       </div>
@@ -827,8 +801,7 @@
               und zwischen Fachbereich und Entwicklung vermittelt.
             </p>
             <p class="mb-3">
-              Im Workshop zeigt er, wie du mit KI aus einer Idee einen Prototypen machst –
-              auch ohne Entwicklerhintergrund.
+              Im Workshop zeigt er, wie du mit KI aus einer Idee einen Prototypen machst.
             </p>
 
             <span class="coach-more">


### PR DESCRIPTION
- Abschnitt „Im Überblick" komplett entfernt (Inhalte bereits in Hero und Angebotsbox)
- Redundante Schlusssätze in „Für wen", „Was du kannst" und „Was du in der Hand hast" entfernt
- Coach-Block: Halbsatz „auch ohne Entwicklerhintergrund" entfernt (bereits im Hero)
- Anker #workshop auf Accordion verschoben

https://claude.ai/code/session_01CMDCCqQTAtzyNutdw3wF69