### PR TITLE
Simplify audience copy: remove redundancy across homepage sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,10 +537,6 @@
           Je nach Zielsetzung als fokussiertes Kurzformat oder als intensiver Halbtages- bzw. Tagesworkshop.
         </li>
         <li>
-          <strong>Zielgruppe</strong><br>
-          Für Produktmenschen, Projektverantwortliche, Innovationsverantwortliche und Fachbereiche, die Ideen schnell greifbar machen wollen.
-        </li>
-        <li>
           <strong>Teilnehmerzahl</strong><br>
           Geeignet für Einzelpersonen, kleine Teams und interdisziplinäre Gruppen.
         </li>
@@ -566,22 +562,13 @@
         </h2>
         <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#workshopAccordion">
           <div class="accordion-body">
-            <p>Dieser Workshop ist für dich, wenn du …</p>
-            <ul class="highlight-list mb-4" style="padding-left: 1.25rem;">
-              <li>Ideen sichtbar machen willst, statt nur darüber zu sprechen</li>
-              <li>mit KI schneller zu echten Ergebnissen kommen möchtest</li>
-              <li>klickbare Prototypen oder kleine Tools bauen willst</li>
-              <li>keine tiefe Programmiererfahrung mitbringst</li>
-              <li>lieber praktisch arbeitest als lange Theorie zu lesen</li>
-            </ul>
-
-            <p class="mb-2" style="font-weight: 700;">Besonders passend für:</p>
+            <p class="mb-2">Besonders passend ist der Workshop zum Beispiel für:</p>
             <div class="row g-3 audience-grid">
               <div class="col-md-6">
                 <div class="card">
                   <div class="card-body">
                     <strong><i class="fas fa-layer-group audience-icon"></i>Produktmanager</strong><br>
-                    <small class="text-muted">Ideen vor Entwicklung validieren</small>
+                    <small class="text-muted">Ideen vor der Entwicklung greifbar machen und früh testen</small>
                   </div>
                 </div>
               </div>
@@ -589,7 +576,7 @@
                 <div class="card">
                   <div class="card-body">
                     <strong><i class="fas fa-comments audience-icon"></i>Kommunikation</strong><br>
-                    <small class="text-muted">Kleine interne Tools ohne IT-Ticket bauen</small>
+                    <small class="text-muted">Kleine interne Tools oder erste Prototypen ohne langes IT-Ticket anstoßen</small>
                   </div>
                 </div>
               </div>
@@ -597,7 +584,7 @@
                 <div class="card">
                   <div class="card-body">
                     <strong><i class="fas fa-lightbulb audience-icon"></i>Innovationsverantwortliche</strong><br>
-                    <small class="text-muted">Workshops mit sichtbarem Outcome statt Post-it-Runden</small>
+                    <small class="text-muted">Workshops mit konkretem Ergebnis statt reiner Ideensammlung gestalten</small>
                   </div>
                 </div>
               </div>
@@ -605,7 +592,7 @@
                 <div class="card">
                   <div class="card-body">
                     <strong><i class="fas fa-diagram-project audience-icon"></i>Fachbereiche</strong><br>
-                    <small class="text-muted">Prototypen für Abstimmungen mit IT erzeugen</small>
+                    <small class="text-muted">Prototypen für Abstimmungen mit IT oder anderen Stakeholdern vorbereiten</small>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
- Remove "Zielgruppe" item from "Der Workshop auf einen Blick" (now org facts only)
- Remove generic intro and bullet points from "Für wen ist der Workshop gemacht?"
- Update audience role cards with more specific use-case descriptions
- Audience is now described broadly in hero, concretely in dedicated section

https://claude.ai/code/session_01W6xkz323Die9sLnrNb9DB4