### PR TITLE
docs: Datenschutz, README und CLAUDE.md auf lokale /vendor-Einbindung aktualisieren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ vibecoding-academy/
 
 - Kein Build-Prozess, kein Bundler, kein Package-Manager
 - CSS und JavaScript sind inline in den HTML-Dateien
-- Externe Abhängigkeiten ausschließlich via CDN (Bootstrap 5.3.2, Font Awesome 6.4.2)
+- Externe Abhängigkeiten lokal im `/vendor`-Verzeichnis (Bootstrap 5.3.2, Font Awesome 6.4.2)
 
 ### Neues Projekt hinzufügen
 
@@ -88,7 +88,7 @@ vibecoding-academy/
 - Externe JavaScript-/CSS-Dateien anlegen, die projektübergreifend geteilt werden (jedes Projekt bleibt selbstständig)
 - Frameworks einführen (kein React, Vue, Angular etc.)
 - Serverseitige Komponenten vorschlagen (kein Node.js, Python etc.)
-- CDN-Links ohne Subresource Integrity (SRI) Hashes einbinden
+- Externe CDN-Links einbinden (alle Abhängigkeiten werden lokal aus `/vendor` geladen)
 
 ---
 
@@ -114,7 +114,7 @@ Vor einem Merge in `main` muss gelten:
 - Responsive Design funktioniert (Desktop + Mobil)
 - Keine Debug-Ausgaben (`console.log`, `alert`) im finalen Code
 - Keine temporären Workarounds
-- CDN-Links haben Integrity-Attribute (SRI)
+- Abhängigkeiten werden aus `/vendor` geladen (keine externen CDN-Aufrufe)
 - Zugänglichkeit: `alt`-Attribute bei Bildern, `aria-label` bei Icon-Buttons
 
 > **Hinweis:** Es gibt kein CI — Prüfung erfolgt manuell vor dem Merge.
@@ -125,7 +125,7 @@ Vor einem Merge in `main` muss gelten:
 
 - Keine Secrets im Code oder Repo (dieses Projekt benötigt keine)
 - Keine `.env`-Dateien (rein statisches Projekt)
-- CDN-Einbindungen immer mit `integrity` und `crossorigin="anonymous"`
+- Keine externen CDN-Einbindungen — Abhängigkeiten liegen lokal im `/vendor`-Verzeichnis
 - Externe Links mit `rel="noopener"` versehen
 
 ---
@@ -135,7 +135,7 @@ Vor einem Merge in `main` muss gelten:
 Dieses Repo hat kein Backend und keine API. OWASP gilt **sinngemäß**:
 
 - **Input-Validation**: Benutzereingaben in Spielen clientseitig validieren
-- **Supply Chain**: CDN-Abhängigkeiten mit SRI-Hashes absichern
+- **Supply Chain**: Abhängigkeiten lokal im `/vendor`-Verzeichnis — keine externe Supply Chain
 - **XSS-Prävention**: Kein `innerHTML` mit unkontrollierten Daten, `textContent` bevorzugen
 - **Secrets**: Keine API-Keys oder Credentials im Frontend-Code
 
@@ -232,31 +232,28 @@ Jede `README.md` in diesem Repository folgt dieser Gliederung. Abschnitte, die n
 > **Zweck:** Einheitliches Design aller Fauteck-Webanwendungen.
 > Dieses Projekt nutzt Bootstrap 5.3 mit anwendungsspezifischem CSS.
 
-### Externe Abhängigkeiten
+### Lokale Abhängigkeiten (`/vendor`)
 
-Jede HTML-Datei bindet im `<head>` ein:
+Bootstrap und Font Awesome werden **lokal** aus dem `/vendor`-Verzeichnis geladen (keine externen CDN-Aufrufe).
+
+Jede HTML-Datei bindet im `<head>` ein (Pfade relativ zur jeweiligen Datei):
 
 ```html
 <!-- Bootstrap 5.3.2 -->
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
-      crossorigin="anonymous">
+<link href="./vendor/bootstrap/bootstrap.min.css" rel="stylesheet">
 
 <!-- Font Awesome 6.4.2 -->
-<link rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
-      crossorigin="anonymous" referrerpolicy="no-referrer">
+<link rel="stylesheet" href="./vendor/fontawesome/css/all.min.css">
 ```
 
 Vor `</body>`:
 
 ```html
 <!-- Bootstrap JS Bundle (inkl. Popper.js) -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
-        crossorigin="anonymous"></script>
+<script src="./vendor/bootstrap/bootstrap.bundle.min.js"></script>
 ```
+
+> **Hinweis:** Für Dateien in Unterordnern (z. B. `apps/pong/`) relative Pfade anpassen: `../../vendor/...`
 
 ### Farbpalette (Design Tokens)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Rein statische Website ohne Backend, Build-Prozess oder Datenbank. Jedes Projekt
 ```
 Browser  ──>  GitHub Pages  ──>  Statische HTML-Dateien
                                   (CSS + JS inline)
-                                  (Bootstrap + Font Awesome via CDN)
+                                  (Bootstrap + Font Awesome lokal aus /vendor)
 ```
 
 ---
@@ -70,8 +70,7 @@ Keine Konfiguration erforderlich. Alle Einstellungen (Farben, Schriften, Breakpo
 
 | Maßnahme | Umsetzung |
 |----------|-----------|
-| **SRI-Hashes** | Alle CDN-Einbindungen (Bootstrap, Font Awesome) mit `integrity`-Attribut |
-| **CORS** | CDN-Links mit `crossorigin="anonymous"` |
+| **Lokale Abhängigkeiten** | Bootstrap und Font Awesome lokal aus `/vendor` — keine externen CDN-Aufrufe |
 | **Externe Links** | Mit `rel="noopener"` versehen |
 | **Keine Secrets** | Kein Backend, keine API-Keys, keine `.env`-Dateien |
 | **XSS-Prävention** | `textContent` statt `innerHTML` mit unkontrollierten Daten |

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -173,28 +173,25 @@
                target="_blank" rel="noopener">Datenschutzerklärung von GitHub</a>.
           </p>
 
-          <!-- Externe Inhalte / CDN -->
+          <!-- Externe Abhängigkeiten -->
           <div class="section-header">
-            <h2>4. Externe Ressourcen (CDN)</h2>
+            <h2>4. Externe Abhängigkeiten</h2>
           </div>
           <p class="mb-2">
-            Beim Laden dieser Website werden folgende externe Ressourcen von Drittanbietern
-            geladen, wodurch technisch Ihre IP-Adresse an diese Anbieter übertragen werden kann:
+            Diese Website verwendet die folgenden Bibliotheken:
           </p>
           <ul class="mb-2">
             <li>
-              <strong>Bootstrap CSS/JS</strong> über jsDelivr (jsDelivr LLC, USA) –
-              CSS-Framework für das Layout der Website.
+              <strong>Bootstrap CSS/JS</strong> – CSS-Framework für das Layout der Website.
             </li>
             <li>
-              <strong>Font Awesome</strong> über Cloudflare CDN (Cloudflare Inc., USA) –
-              Icon-Bibliothek für Symbole auf der Website.
+              <strong>Font Awesome</strong> – Icon-Bibliothek für Symbole auf der Website.
             </li>
           </ul>
           <p class="mb-4">
-            Alle externen Ressourcen werden mit Subresource Integrity (SRI) eingebunden, sodass
-            nur geprüfte Versionen geladen werden. Die Einbindung erfolgt auf Grundlage berechtigter
-            Interessen (Art. 6 Abs. 1 lit. f DSGVO) am fehlerfreien Betrieb der Website.
+            Beide Bibliotheken werden lokal vom eigenen Server (GitHub Pages) ausgeliefert und
+            nicht über externe CDN-Dienste geladen. Es findet daher kein Datentransfer an
+            Drittanbieter wie jsDelivr oder Cloudflare statt.
           </p>
 
           <!-- Kontaktaufnahme per E-Mail -->


### PR DESCRIPTION
Bootstrap und Font Awesome werden längst lokal aus /vendor geladen,
aber die Dokumentation sprach noch von CDN-Einbindungen über jsDelivr
und Cloudflare. Alle drei Dateien an den tatsächlichen Stand angepasst.

https://claude.ai/code/session_01FmFtMXG2tZeKRYgk7VKVev