### PR TITLE
CTA-Texte und -Platzierungen konsistent überarbeiten

### DIFF
--- a/agb.html
+++ b/agb.html
@@ -93,6 +93,7 @@
         <a class="site-nav-link" href="./wiki/">Wiki</a>
         <a class="site-nav-link" href="./projekte/">Projekte</a>
         <a class="site-nav-link" href="./ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="./kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -103,6 +104,7 @@
         <a class="site-nav-link" href="./wiki/">Wiki</a>
         <a class="site-nav-link" href="./projekte/">Projekte</a>
         <a class="site-nav-link" href="./ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="./kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>

--- a/apps/gta/index.html
+++ b/apps/gta/index.html
@@ -231,6 +231,7 @@
         <a class="site-nav-link" href="../../wiki/">Wiki</a>
         <a class="site-nav-link active" href="../../projekte/">Projekte</a>
         <a class="site-nav-link" href="../../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../../kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -241,6 +242,7 @@
         <a class="site-nav-link" href="../../wiki/">Wiki</a>
         <a class="site-nav-link" href="../../projekte/">Projekte</a>
         <a class="site-nav-link" href="../../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../../kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>

--- a/apps/pong/index.html
+++ b/apps/pong/index.html
@@ -79,6 +79,7 @@
         <a class="site-nav-link" href="../../wiki/">Wiki</a>
         <a class="site-nav-link active" href="../../projekte/">Projekte</a>
         <a class="site-nav-link" href="../../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../../kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -89,6 +90,7 @@
         <a class="site-nav-link" href="../../wiki/">Wiki</a>
         <a class="site-nav-link" href="../../projekte/">Projekte</a>
         <a class="site-nav-link" href="../../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../../kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>

--- a/apps/wochenendplanung/index.html
+++ b/apps/wochenendplanung/index.html
@@ -172,6 +172,7 @@
         <a class="site-nav-link" href="../../wiki/">Wiki</a>
         <a class="site-nav-link active" href="../../projekte/">Projekte</a>
         <a class="site-nav-link" href="../../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../../kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -182,6 +183,7 @@
         <a class="site-nav-link" href="../../wiki/">Wiki</a>
         <a class="site-nav-link" href="../../projekte/">Projekte</a>
         <a class="site-nav-link" href="../../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../../kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>

--- a/css/nav.css
+++ b/css/nav.css
@@ -134,10 +134,38 @@
   background: var(--bg-page, #EEF2F7);
 }
 
+.site-nav-dropdown .site-nav-cta {
+  display: block;
+  margin: 0.5rem 3rem;
+  text-align: center;
+  padding: 0.6rem 1rem;
+}
+
 /* ── Body Offset ─────────────────────────────────── */
 
 body {
   padding-top: 4.5rem;
+}
+
+/* ── Nav CTA Button ──────────────────────────────── */
+
+.site-nav-cta {
+  display: inline-block;
+  padding: 0.45rem 1rem;
+  background: var(--primary-color, #5B8BD6);
+  color: #fff !important;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 6px;
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+  white-space: nowrap;
+}
+
+.site-nav-cta:hover {
+  opacity: 0.85;
+  color: #fff !important;
+  text-decoration: none;
 }
 
 /* ── Responsive ──────────────────────────────────── */
@@ -157,5 +185,8 @@ body {
   }
   .site-nav-dropdown .site-nav-link {
     padding: 0.75rem 1.5rem;
+  }
+  .site-nav-dropdown .site-nav-cta {
+    margin: 0.5rem 1.5rem;
   }
 }

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -93,6 +93,7 @@
         <a class="site-nav-link" href="./wiki/">Wiki</a>
         <a class="site-nav-link" href="./projekte/">Projekte</a>
         <a class="site-nav-link" href="./ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="./kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -103,6 +104,7 @@
         <a class="site-nav-link" href="./wiki/">Wiki</a>
         <a class="site-nav-link" href="./projekte/">Projekte</a>
         <a class="site-nav-link" href="./ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="./kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>

--- a/hosting/index.html
+++ b/hosting/index.html
@@ -148,6 +148,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -158,6 +159,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>

--- a/impressum.html
+++ b/impressum.html
@@ -93,6 +93,7 @@
         <a class="site-nav-link" href="./wiki/">Wiki</a>
         <a class="site-nav-link" href="./projekte/">Projekte</a>
         <a class="site-nav-link" href="./ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="./kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -103,6 +104,7 @@
         <a class="site-nav-link" href="./wiki/">Wiki</a>
         <a class="site-nav-link" href="./projekte/">Projekte</a>
         <a class="site-nav-link" href="./ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="./kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>

--- a/index.html
+++ b/index.html
@@ -554,6 +554,7 @@
         <a class="site-nav-link" href="./wiki/">Wiki</a>
         <a class="site-nav-link" href="./projekte/">Projekte</a>
         <a class="site-nav-link" href="./ueber-mich/">Coach</a>
+        <a class="site-nav-cta" href="./kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -564,6 +565,7 @@
         <a class="site-nav-link" href="./wiki/">Wiki</a>
         <a class="site-nav-link" href="./projekte/">Projekte</a>
         <a class="site-nav-link" href="./ueber-mich/">Coach</a>
+        <a class="site-nav-cta" href="./kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>
@@ -584,8 +586,8 @@
         <a href="./kontakt/" class="hero-cta">
           <i class="fas fa-envelope me-2"></i>Workshop anfragen
         </a>
-        <a href="#workshop" class="hero-link">
-          So läuft der Workshop ab <i class="fas fa-arrow-down ms-1"></i>
+        <a href="./kontakt/" class="hero-link">
+          <i class="fas fa-clipboard-check me-1"></i>Workshop-Fit prüfen
         </a>
       </div>
     </div>
@@ -638,6 +640,12 @@
           </div>
         </div>
       </div>
+    </div>
+
+    <div class="text-center mb-4">
+      <a href="./kontakt/" class="hero-cta">
+        <i class="fas fa-comments me-2"></i>Workshop-Format besprechen
+      </a>
     </div>
 
     <div id="workshop"></div>
@@ -731,6 +739,11 @@
               </div>
             </div>
             <p>Außerdem weißt du danach, wie du ähnliche Ideen mit KI schneller strukturierst, baust und weiterentwickelst.</p>
+            <div class="text-center mt-3">
+              <a href="./kontakt/" class="hero-cta">
+                <i class="fas fa-lightbulb me-2"></i>Eigenen Anwendungsfall besprechen
+              </a>
+            </div>
           </div>
         </div>
       </div>
@@ -789,6 +802,11 @@
                   </div>
                 </div>
               </div>
+            </div>
+            <div class="text-center mt-3">
+              <a href="./kontakt/" class="hero-cta">
+                <i class="fas fa-calendar-check me-2"></i>Ablauf für dich oder dein Team abstimmen
+              </a>
             </div>
           </div>
         </div>
@@ -886,7 +904,7 @@
             </p>
 
             <span class="coach-more">
-              Mehr über deinen Coach <i class="fas fa-arrow-right"></i>
+              Mehr über Niklas Fauteck <i class="fas fa-arrow-right"></i>
             </span>
           </div>
         </div>
@@ -894,16 +912,16 @@
     </a>
 
     <div class="section-header mt-4">
-      <h5><i class="fas fa-paper-plane me-2"></i>Workshop für dich oder dein Team anfragen</h5>
+      <h5><i class="fas fa-paper-plane me-2"></i>Workshop für dein Team abstimmen</h5>
     </div>
 
     <div class="cta-box mb-4">
-      <h5 class="mb-3" style="font-weight: 700;">Unverbindlich Format, Termin und Schwerpunkt abstimmen</h5>
+      <h5 class="mb-3" style="font-weight: 700;">In 2 Minuten anfragen – ich sage dir offen, welches Format sinnvoll ist</h5>
       <p class="mb-3">
         Teile kurz mit, woran du arbeitest. Danach erhältst du eine passende Einschätzung zum Workshop und den nächsten sinnvollen Schritten.
       </p>
       <a href="./kontakt/" class="hero-cta">
-        <i class="fas fa-envelope me-2"></i>Jetzt unverbindlich anfragen
+        <i class="fas fa-envelope me-2"></i>Workshop-Fit prüfen
       </a>
     </div>
 

--- a/kontakt/index.html
+++ b/kontakt/index.html
@@ -258,6 +258,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -268,6 +269,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>
@@ -316,7 +318,7 @@
           <div class="card-icon"><i class="fas fa-envelope"></i></div>
           <div class="card-title">E-Mail</div>
           <div class="card-value">
-            <a href="mailto:me@fauteck.eu">me@fauteck.eu</a>
+            <a href="mailto:ki@fauteck.eu">ki@fauteck.eu</a>
           </div>
         </div>
 
@@ -331,7 +333,7 @@
 
       <!-- Contact Form -->
       <div class="contact-form-section">
-        <h2><i class="fas fa-paper-plane me-2"></i>Nachricht senden</h2>
+        <h2><i class="fas fa-paper-plane me-2"></i>Workshop-Fit-Check starten</h2>
         <form class="contact-form" id="contactForm" novalidate>
           <div class="form-row">
             <div class="form-group">
@@ -401,7 +403,7 @@
             <textarea id="cf-message" name="message" required placeholder="Beschreibe kurz, woran du arbeitest und was du dir vom Workshop erhoffst."></textarea>
           </div>
           <button type="submit" class="cta-btn">
-            Nachricht senden &rarr;
+            Workshop anfragen
           </button>
           <div class="form-success" id="formSuccess">
             <i class="fas fa-check me-1"></i> Dein E-Mail-Programm wurde geöffnet. Sende die E-Mail ab, um deine Anfrage abzuschließen.
@@ -451,7 +453,7 @@
       }
 
       var body = 'Name: ' + name + '\nE-Mail: ' + email + fitCheck + '\n\nNachricht:\n' + message;
-      var mailto = 'mailto:me@fauteck.eu'
+      var mailto = 'mailto:ki@fauteck.eu'
         + '?subject=' + encodeURIComponent(subject)
         + '&body='    + encodeURIComponent(body);
 

--- a/projekte/index.html
+++ b/projekte/index.html
@@ -150,6 +150,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link active" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -160,6 +161,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>
@@ -173,6 +175,11 @@
       <p class="mx-auto" style="max-width: 600px;">
         Beispielideen, Ergebnisse und Inspiration für eigene kleine Anwendungen
       </p>
+      <div style="margin-top: 1.2rem;">
+        <a href="../kontakt/" style="display: inline-block; padding: 0.82rem 1.45rem; background: #fff; color: var(--secondary-color, #3D5A8C); font-weight: 700; font-size: 1rem; border-radius: 8px; text-decoration: none; box-shadow: 0 4px 15px rgba(0,0,0,0.12);">
+          <i class="fas fa-rocket me-2"></i>Eigenes Projekt im Workshop starten
+        </a>
+      </div>
     </div>
   </div>
 
@@ -213,13 +220,16 @@
         </a>
       </div>
       <div class="col-md-4 col-sm-6">
-        <div class="card h-100" style="border: 2px dashed var(--border-color);">
-          <div class="card-body text-center text-muted d-flex flex-column justify-content-center">
+        <a class="card text-decoration-none h-100" href="../kontakt/" style="border: 2px dashed var(--primary-color);">
+          <div class="card-body text-center d-flex flex-column justify-content-center">
             <div class="fs-1 mb-2">🚀</div>
-            <h6 class="card-title">Dein Projekt?</h6>
-            <p class="card-text small">Erstelle im Workshop dein eigenes Projekt!</p>
+            <h6 class="card-title">Dein Anwendungsfall</h6>
+            <p class="card-text small" style="color: var(--text-muted);">Im Workshop entsteht ein erster Prototyp für euren echten Use Case</p>
+            <span class="mt-auto" style="color: var(--primary-color); font-weight: 600; font-size: 0.9rem;">
+              Pilot anfragen <i class="fas fa-arrow-right ms-1"></i>
+            </span>
           </div>
-        </div>
+        </a>
       </div>
     </div>
 
@@ -320,6 +330,14 @@
           </div>
         </a>
       </div>
+    </div>
+
+    <div style="background: linear-gradient(135deg, rgba(91,139,214,0.12), rgba(92,198,167,0.12)); border: 1px solid var(--border-color); border-radius: var(--border-radius-card, 12px); padding: 1.35rem; text-align: center;" class="mb-4">
+      <h5 style="font-weight: 700;" class="mb-2">Aus einer Idee ein eigenes Projekt machen?</h5>
+      <p class="mb-3" style="max-width: 600px; margin: 0 auto;">Wenn ihr einen konkreten Anwendungsfall habt, lässt sich daraus im Workshop ein erster Prototyp entwickeln.</p>
+      <a href="../kontakt/" style="display: inline-block; padding: 0.82rem 1.45rem; background: #fff; color: var(--secondary-color, #3D5A8C); font-weight: 700; border-radius: 8px; text-decoration: none; box-shadow: 0 4px 15px rgba(0,0,0,0.12);">
+        <i class="fas fa-envelope me-2"></i>Workshop anfragen
+      </a>
     </div>
 
   </main>

--- a/projekte/viewer.html
+++ b/projekte/viewer.html
@@ -61,6 +61,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link active" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -71,6 +72,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>

--- a/ueber-mich/index.html
+++ b/ueber-mich/index.html
@@ -205,6 +205,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link active" href="../ueber-mich/">Coach</a>
+        <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -215,6 +216,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>
@@ -246,6 +248,11 @@
           </a>
           <a class="contact-link" href="https://fauteck.github.io/website" target="_blank" rel="noopener">
             <i class="fas fa-globe"></i> Website
+          </a>
+        </div>
+        <div style="margin-top: 1rem;">
+          <a href="../kontakt/" style="display: inline-block; padding: 0.7rem 1.3rem; background: var(--primary-color); color: #fff; font-weight: 600; border-radius: 8px; text-decoration: none; font-size: 0.95rem;">
+            <i class="fas fa-envelope me-2"></i>Workshop mit Niklas anfragen
           </a>
         </div>
       </div>
@@ -296,6 +303,15 @@
         <div class="bio-text">
           <p>Abseits des Schreibtischs baue ich Smart-Home-Systeme, experimentiere mit 3D-Druckern und habe viele Jahre Science Slams moderiert. Die Überzeugung dahinter: Dinge einfach anfangen, scheitern, besser machen. Dieselbe Mentalität steckt in jedem Projekt, das ich anfasse.</p>
         </div>
+      </div>
+
+      <!-- Abschluss-CTA -->
+      <div style="background: linear-gradient(135deg, rgba(91,139,214,0.12), rgba(92,198,167,0.12)); border: 1px solid var(--border-color); border-radius: 12px; padding: 1.35rem; text-align: center; margin-top: 1.5rem;">
+        <h5 style="font-weight: 700;" class="mb-2">Passt die Arbeitsweise zu eurem Team?</h5>
+        <p class="mb-3">Dann lass uns kurz über Ziel, Teamgröße und sinnvolles Format sprechen.</p>
+        <a href="../kontakt/" style="display: inline-block; padding: 0.7rem 1.3rem; background: var(--primary-color); color: #fff; font-weight: 600; border-radius: 8px; text-decoration: none;">
+          <i class="fas fa-envelope me-2"></i>Workshop anfragen
+        </a>
       </div>
 
     </div>

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -598,6 +598,7 @@
         <a class="site-nav-link active" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
       <button class="site-nav-hamburger" aria-label="Menü" aria-expanded="false"
               onclick="this.classList.toggle('open');this.nextElementSibling.classList.toggle('open');this.setAttribute('aria-expanded',this.classList.contains('open'))">
@@ -608,6 +609,7 @@
         <a class="site-nav-link" href="../wiki/">Wiki</a>
         <a class="site-nav-link" href="../projekte/">Projekte</a>
         <a class="site-nav-link" href="../ueber-mich/">Coach</a>
+              <a class="site-nav-cta" href="../kontakt/">Workshop anfragen</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
- Nav: CTA-Button „Workshop anfragen" in globaler Navigation ergänzt (alle 13 Seiten)
- Hero: Sekundären CTA zu „Workshop-Fit prüfen" geändert (→ Kontaktseite)
- Startseite: CTAs nach „Auf einen Blick", „Was du mitnimmst" und „Ablauf" ergänzt
- Coach-Teaser: „Mehr über deinen Coach" → „Mehr über Niklas Fauteck"
- Abschlussblock: Überschrift, Subline und Button überarbeitet
- Projekte: Hero-CTA, klickbare „Dein Anwendungsfall"-Karte und Abschluss-CTA ergänzt
- Coach-Seite: Workshop-CTA im Profilkopf und Abschlussblock ergänzt
- Kontaktseite: Formular-Überschrift und Submit-Button angepasst
- E-Mail auf ki@fauteck.eu vereinheitlicht (Kontaktseite)

https://claude.ai/code/session_01JjMCK7ZGm1r1tEg3USJiXU