### PR TITLE
Update sitemap with lastmod dates and new pages

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,30 +2,47 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://fauteck.github.io/vibecoding-academy/</loc>
+    <lastmod>2026-04-02</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://fauteck.github.io/vibecoding-academy/apps/pong/</loc>
+    <lastmod>2026-04-02</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://fauteck.github.io/vibecoding-academy/apps/gta/</loc>
+    <lastmod>2026-04-02</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://fauteck.github.io/vibecoding-academy/apps/wochenendplanung/</loc>
+    <lastmod>2026-04-02</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://fauteck.github.io/vibecoding-academy/wiki/</loc>
+    <lastmod>2026-04-02</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://fauteck.github.io/vibecoding-academy/projekte/viewer.html</loc>
-    <priority>0.6</priority>
+    <loc>https://fauteck.github.io/vibecoding-academy/projekte/</loc>
+    <lastmod>2026-04-02</lastmod>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://fauteck.github.io/vibecoding-academy/ueber-mich/</loc>
+    <lastmod>2026-04-02</lastmod>
     <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://fauteck.github.io/vibecoding-academy/kontakt/</loc>
+    <lastmod>2026-04-02</lastmod>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://fauteck.github.io/vibecoding-academy/hosting/</loc>
+    <lastmod>2026-04-02</lastmod>
+    <priority>0.5</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
Updated the sitemap.xml to include last modification dates for all URLs and added two new pages to the sitemap. Also adjusted the priority of the projects page.

## Key Changes
- Added `<lastmod>2026-04-02</lastmod>` entries to all existing URLs for better SEO and cache management
- Changed projects URL from `/projekte/viewer.html` to `/projekte/` (directory-level) and increased priority from 0.6 to 0.7
- Added two new pages to the sitemap:
  - `/kontakt/` (contact page) with priority 0.5
  - `/hosting/` (hosting page) with priority 0.5

## Implementation Details
- All modification dates are set to 2026-04-02, indicating a recent update
- Priority values follow a logical hierarchy with the homepage at 1.0, main apps at 0.8, and new pages at 0.5
- The projects page restructuring suggests a migration from a single viewer.html file to a full directory-based structure

https://claude.ai/code/session_01MA2p4WNkh9T5dbDCubLTur