### PR TITLE
Add canonical URLs to all pages for SEO

### DIFF
--- a/agb.html
+++ b/agb.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230f0f1a'/%3E%3Ctext x='2' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%237c3aed'%3E%26lt;%3C/text%3E%3Ctext x='18' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%2306b6d4'%3E%26gt;%3C/text%3E%3Cpath d='M17 8 L13 17 L18 17 L15 26' stroke='url(%23g)' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0' stop-color='%23c4b5fd'/%3E%3Cstop offset='1' stop-color='%2306b6d4'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E">
   <meta name="description" content="Allgemeine Geschäftsbedingungen der Vibecoding Academy">
   <meta name="robots" content="noindex">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/agb.html">
   <meta property="og:locale" content="de_DE">
   <meta name="theme-color" content="#5B8BD6">
 

--- a/apps/gta/index.html
+++ b/apps/gta/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   <title>Grand Thomas Auto 6 - Vibecoding Academy</title>
   <meta name="description" content="GTA-Parodie als Browser-Spiel – erstellt mit KI-gestütztem Vibecoding.">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/apps/gta/">
   <meta property="og:title" content="Grand Thomas Auto 6 - Vibecoding Academy">
   <meta property="og:description" content="GTA-Parodie als Browser-Spiel – erstellt mit KI-gestütztem Vibecoding.">
   <meta property="og:type" content="website">

--- a/apps/pong/index.html
+++ b/apps/pong/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Pong - Vibecoding Academy</title>
   <meta name="description" content="Klassisches Pong-Spiel – gebaut mit KI im Vibecoding-Workshop.">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/apps/pong/">
   <meta property="og:title" content="Pong - Vibecoding Academy">
   <meta property="og:description" content="Klassisches Pong-Spiel – gebaut mit KI im Vibecoding-Workshop.">
   <meta property="og:type" content="website">

--- a/apps/wochenendplanung/index.html
+++ b/apps/wochenendplanung/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wochenendplanung - Vibecoding Academy</title>
   <meta name="description" content="Wochenendplanung-App – erstellt im Vibecoding-Workshop mit KI-Unterstützung.">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/apps/wochenendplanung/">
   <meta property="og:title" content="Wochenendplanung - Vibecoding Academy">
   <meta property="og:description" content="Wochenendplanung-App – erstellt im Vibecoding-Workshop mit KI-Unterstützung.">
   <meta property="og:type" content="website">

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230f0f1a'/%3E%3Ctext x='2' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%237c3aed'%3E%26lt;%3C/text%3E%3Ctext x='18' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%2306b6d4'%3E%26gt;%3C/text%3E%3Cpath d='M17 8 L13 17 L18 17 L15 26' stroke='url(%23g)' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0' stop-color='%23c4b5fd'/%3E%3Cstop offset='1' stop-color='%2306b6d4'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E">
   <meta name="description" content="Datenschutzerklärung der Vibecoding Academy gemäß DSGVO">
   <meta name="robots" content="noindex">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/datenschutz.html">
   <meta property="og:locale" content="de_DE">
   <meta name="theme-color" content="#5B8BD6">
 

--- a/hosting/index.html
+++ b/hosting/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hosting-Anleitung – Vibecoding Academy</title>
   <meta name="description" content="Hosting-Anleitung für Vibecoding-Projekte: lokal ausführen, GitHub Pages, Docker. Von der Idee bis zur veröffentlichten Web-Anwendung.">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/hosting/">
   <meta property="og:title" content="Hosting-Anleitung – Vibecoding Academy">
   <meta property="og:description" content="Drei Wege, dein Projekt live zu bringen: lokal, GitHub Pages, Docker.">
   <meta property="og:type" content="website">

--- a/impressum.html
+++ b/impressum.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230f0f1a'/%3E%3Ctext x='2' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%237c3aed'%3E%26lt;%3C/text%3E%3Ctext x='18' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%2306b6d4'%3E%26gt;%3C/text%3E%3Cpath d='M17 8 L13 17 L18 17 L15 26' stroke='url(%23g)' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0' stop-color='%23c4b5fd'/%3E%3Cstop offset='1' stop-color='%2306b6d4'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E">
   <meta name="description" content="Impressum der Vibecoding Academy – Angaben gemäß § 5 TMG">
   <meta name="robots" content="noindex">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/impressum.html">
   <meta property="og:locale" content="de_DE">
   <meta name="theme-color" content="#5B8BD6">
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Vibecoding Academy</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230f0f1a'/%3E%3Ctext x='2' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%237c3aed'%3E%26lt;%3C/text%3E%3Ctext x='18' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%2306b6d4'%3E%26gt;%3C/text%3E%3Cpath d='M17 8 L13 17 L18 17 L15 26' stroke='url(%23g)' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0' stop-color='%23c4b5fd'/%3E%3Cstop offset='1' stop-color='%2306b6d4'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E">
   <meta name="description" content="Baue mit KI funktionierende Prototypen – auch ohne Programmiererfahrung. Praxisnaher Workshop für kleine Web-Apps, interne Tools und erste Produktideen.">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/">
   <meta property="og:title" content="Vibecoding Academy – Workshop">
   <meta property="og:description" content="Baue mit KI funktionierende Prototypen – auch ohne Programmiererfahrung. Praxisnaher Workshop für kleine Web-Apps, interne Tools und erste Produktideen.">
   <meta property="og:type" content="website">

--- a/kontakt/index.html
+++ b/kontakt/index.html
@@ -6,6 +6,7 @@
   <title>Kontakt - Vibecoding Academy</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230f0f1a'/%3E%3Ctext x='2' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%237c3aed'%3E%26lt;%3C/text%3E%3Ctext x='18' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%2306b6d4'%3E%26gt;%3C/text%3E%3Cpath d='M17 8 L13 17 L18 17 L15 26' stroke='url(%23g)' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0' stop-color='%23c4b5fd'/%3E%3Cstop offset='1' stop-color='%2306b6d4'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E">
   <meta name="description" content="Kontakt - Vibecoding Academy. Lass uns über deine Herausforderungen sprechen.">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/kontakt/">
   <meta property="og:title" content="Kontakt - Vibecoding Academy">
   <meta property="og:description" content="Kontakt - Vibecoding Academy. Lass uns über deine Herausforderungen sprechen.">
   <meta property="og:type" content="website">

--- a/projekte/index.html
+++ b/projekte/index.html
@@ -6,6 +6,7 @@
   <title>Projekte – Vibecoding Academy</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230f0f1a'/%3E%3Ctext x='2' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%237c3aed'%3E%26lt;%3C/text%3E%3Ctext x='18' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%2306b6d4'%3E%26gt;%3C/text%3E%3Cpath d='M17 8 L13 17 L18 17 L15 26' stroke='url(%23g)' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0' stop-color='%23c4b5fd'/%3E%3Cstop offset='1' stop-color='%2306b6d4'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E">
   <meta name="description" content="Projekte der Vibecoding Academy - Ideen, Konzepte und fertige Ergebnisse aus dem Workshop.">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/projekte/">
   <meta property="og:title" content="Projekte – Vibecoding Academy">
   <meta property="og:description" content="Ideen, Konzepte und fertige Ergebnisse aus dem Workshop.">
   <meta property="og:type" content="website">

--- a/projekte/viewer.html
+++ b/projekte/viewer.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Idee - Vibecoding Academy</title>
   <meta name="description" content="Spielkonzepte und Ideen für den Vibecoding-Workshop – von Flappy Bird bis Tetris.">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/projekte/viewer.html">
   <meta property="og:title" content="Spielideen - Vibecoding Academy">
   <meta property="og:description" content="Spielkonzepte und Ideen für den Vibecoding-Workshop – von Flappy Bird bis Tetris.">
   <meta property="og:type" content="website">

--- a/ueber-mich/index.html
+++ b/ueber-mich/index.html
@@ -6,6 +6,7 @@
   <title>Dein Coach - Vibecoding Academy</title>
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230f0f1a'/%3E%3Ctext x='2' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%237c3aed'%3E%26lt;%3C/text%3E%3Ctext x='18' y='23' font-family='monospace' font-size='20' font-weight='bold' fill='%2306b6d4'%3E%26gt;%3C/text%3E%3Cpath d='M17 8 L13 17 L18 17 L15 26' stroke='url(%23g)' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' y1='0' x2='0' y2='1'%3E%3Cstop offset='0' stop-color='%23c4b5fd'/%3E%3Cstop offset='1' stop-color='%2306b6d4'/%3E%3C/linearGradient%3E%3C/defs%3E%3C/svg%3E">
   <meta name="description" content="Niklas Fauteck - Coach für Digitale Transformation und KI-gestütztes Vibecoding">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/ueber-mich/">
   <meta property="og:title" content="Dein Coach - Vibecoding Academy">
   <meta property="og:description" content="Niklas Fauteck - Coach für Digitale Transformation und KI-gestütztes Vibecoding.">
   <meta property="og:type" content="website">

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wiki – Vibecoding Academy</title>
   <meta name="description" content="Handout und Lernpfad durch die wichtigsten Grundlagen, Methoden und Grenzen des Vibecodings.">
+  <link rel="canonical" href="https://fauteck.github.io/vibecoding-academy/wiki/">
   <meta property="og:title" content="Wiki – Vibecoding Academy">
   <meta property="og:description" content="Handout und Lernpfad durch die wichtigsten Grundlagen, Methoden und Grenzen des Vibecodings.">
   <meta property="og:type" content="website">


### PR DESCRIPTION
## Summary
Added canonical URL meta tags to all HTML pages across the Vibecoding Academy website to improve SEO and prevent duplicate content issues.

## Changes
- Added `<link rel="canonical">` tags to 14 HTML pages
- Each canonical URL points to the absolute URL on the GitHub Pages domain (`https://fauteck.github.io/vibecoding-academy/`)
- Covers all main pages: homepage, legal pages (AGB, Datenschutz, Impressum), content pages (Wiki, Projekte, Kontakt, Über mich), app pages (GTA, Pong, Wochenendplanung), and utility pages (Hosting, Viewer)

## Implementation Details
- Canonical tags are placed in the `<head>` section after the description meta tag
- URLs follow the site structure with trailing slashes for directory-based pages
- Ensures search engines recognize the authoritative version of each page, preventing SEO penalties from duplicate content

https://claude.ai/code/session_01VjKbMkETUC9EinZCqDqQyZ