### PR TITLE
Update landing page marketing copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -591,15 +591,15 @@
     <div class="hero-inner">
       <span class="badge hero-badge mb-3">Praxisworkshop · Remote oder vor Ort</span>
 
-      <h1>KI-Prototyping selbst ausprobieren -- und danach wissen, was damit wirklich machbar ist.</h1>
+      <h1>KI-Prototyping selbst ausprobieren - und danach wissen, was damit wirklich machbar ist.</h1>
 
       <p class="hero-lead mx-auto mt-3 mb-0">
-        Du bringst eine Idee mit. Du baust sie. Du gehst mit einem Prototypen raus -- und dem Wissen, wie du ihn selbst weiterentwickelst.
+        Du bringst eine Idee mit, baust sie - und gehst mit einem Prototypen raus, den du selbst weiterentwickeln kannst.
       </p>
 
       <div class="hero-actions">
         <a href="./kontakt/" class="hero-cta">
-          <i class="fas fa-envelope me-2"></i>In 2 Minuten anfragen — ich sage dir ehrlich, ob es passt
+          <i class="fas fa-envelope me-2"></i>In 2 Minuten anfragen - ich sage dir ehrlich, ob es passt
         </a>
         <a href="#angebot" class="hero-link">
           <i class="fas fa-arrow-down me-1"></i>Ablauf und Formate ansehen
@@ -613,8 +613,8 @@
     <div class="overview-box" id="warum-jetzt">
       <h2><i class="fas fa-bolt me-2"></i>Warum gerade jetzt?</h2>
       <p class="mb-2">Die meisten KI-Workshops enden mit vollen Slide-Decks und dem Gefühl, das Thema immer noch nicht wirklich angefasst zu haben.</p>
-      <p class="mb-2">Hier ist das anders. Du arbeitest direkt mit echten Tools: KI-Chats, eigene Beispiele, echte Ergebnisse. Du probierst aus, machst Fehler, fixst sie -- und weisst danach konkret, was mit KI-Prototyping in deinem Kontext machbar ist und wie du selbst weitermachst.</p>
-      <p class="mb-0">Besonders wenn du mit Entwicklung oder IT zusammenarbeitest: Ein Prototyp ersetzt hundert Worte in einem Anforderungsdokument. Du zeigst, was du meinst -- statt es zu beschreiben. Und Entwickler können gezielter arbeiten, wenn der Prozess schon sichtbar ist.</p>
+      <p class="mb-2">Hier ist das anders. Du arbeitest direkt mit echten Tools: KI-Chats, eigene Beispiele, echte Ergebnisse. Du probierst aus, machst Fehler, fixst sie - und weisst danach konkret, was mit KI-Prototyping in deinem Kontext machbar ist und wie du selbst weitermachst.</p>
+      <p class="mb-0">Besonders wenn du mit Entwicklung oder IT zusammenarbeitest: Ein Prototyp macht konkret, was im Anforderungsdokument abstrakt bleibt. Du zeigst, was du meinst - statt es zu beschreiben. Und Entwickler können gezielter arbeiten, wenn der Prozess schon sichtbar ist.</p>
     </div>
 
     <div class="overview-box" id="angebot">
@@ -624,7 +624,7 @@
           <div class="card h-100">
             <div class="card-body">
               <strong>Format</strong><br>
-              <small class="text-muted">Kompakt-Session (3 h), Halbtagsformat (4–5 h) oder intensiver Tagesworkshop. Remote per Videocall oder vor Ort bei euch.</small>
+              <small class="text-muted">Kompakt-Session (3 h), Halbtagsformat (4-5 h) oder intensiver Tagesworkshop. Remote per Videocall oder vor Ort bei euch.</small>
             </div>
           </div>
         </div>
@@ -632,7 +632,7 @@
           <div class="card h-100">
             <div class="card-body">
               <strong>Teilnehmer</strong><br>
-              <small class="text-muted">1–8 Personen. Funktioniert als Einzelcoaching, im Team oder gemischt über Abteilungen hinweg.</small>
+              <small class="text-muted">1-8 Personen. Funktioniert als Einzelcoaching, im Team oder gemischt über Abteilungen hinweg.</small>
             </div>
           </div>
         </div>
@@ -648,7 +648,7 @@
           <div class="card h-100">
             <div class="card-body">
               <strong>Ablauf</strong><br>
-              <small class="text-muted">Du beschreibst kurz, woran du arbeitest. Ich schlage ein passendes Format vor. Du bekommst ein unverbindliches Angebot — in der Regel innerhalb von 24 Stunden.</small>
+              <small class="text-muted">Du beschreibst kurz, woran du arbeitest. Ich schlage ein passendes Format vor. Du bekommst ein unverbindliches Angebot - in der Regel innerhalb von 24 Stunden.</small>
             </div>
           </div>
         </div>
@@ -685,7 +685,7 @@
                 <div class="card">
                   <div class="card-body">
                     <strong><i class="fas fa-layer-group audience-icon"></i>Produktmanager</strong><br>
-                    <small class="text-muted">Du willst eine Feature-Idee testen, bevor Entwicklung involviert wird? Bau sie an einem Nachmittag selbst — und teste sie am nächsten Tag mit echten Nutzern.</small>
+                    <small class="text-muted">Du willst eine Idee testen, bevor Entwicklung involviert wird? Bau sie selbst - und geh mit echtem Feedback in die nächste Runde.</small>
                   </div>
                 </div>
               </div>
@@ -693,7 +693,7 @@
                 <div class="card">
                   <div class="card-body">
                     <strong><i class="fas fa-comments audience-icon"></i>Kommunikations- und Redaktionsteams</strong><br>
-                    <small class="text-muted">Ihr braucht ein kleines internes Tool, aber der IT-Backlog ist voll? Baut den ersten Entwurf selbst. Wenn er funktioniert, nimmt IT ihn ernst.</small>
+                    <small class="text-muted">Der IT-Backlog ist voll, aber ihr braucht ein Tool? Baut den ersten Entwurf selbst. Wenn er funktioniert, nimmt IT ihn ernst.</small>
                   </div>
                 </div>
               </div>
@@ -701,7 +701,7 @@
                 <div class="card">
                   <div class="card-body">
                     <strong><i class="fas fa-lightbulb audience-icon"></i>Innovationsverantwortliche</strong><br>
-                    <small class="text-muted">Dein nächster Workshop soll nicht mit Post-its enden, sondern mit einem klickbaren Ergebnis? Genau dafür ist dieses Format gemacht.</small>
+                    <small class="text-muted">Euer nächster Workshop soll nicht mit Post-its enden? Hier verlässt ihr den Raum mit etwas Klickbarem.</small>
                   </div>
                 </div>
               </div>
@@ -709,7 +709,7 @@
                 <div class="card">
                   <div class="card-body">
                     <strong><i class="fas fa-diagram-project audience-icon"></i>Fachbereiche</strong><br>
-                    <small class="text-muted">Du willst der Entwicklung zeigen, was du meinst — nicht nur beschreiben? Ein Prototyp sagt mehr als ein 20-seitiges Anforderungsdokument.</small>
+                    <small class="text-muted">Du willst zeigen was du meinst, statt es zu beschreiben? Ein Prototyp ergänzt jedes Anforderungsdokument.</small>
                   </div>
                 </div>
               </div>
@@ -727,38 +727,8 @@
         </h2>
         <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#workshopAccordion">
           <div class="accordion-body">
-            <p>Je nach Ziel und Ausgangslage nimmst du ein konkretes Ergebnis mit, zum Beispiel:</p>
-            <div class="row g-3 mb-3">
-              <div class="col-md-6">
-                <div class="card">
-                  <div class="card-body">
-                    <strong><i class="fas fa-mouse-pointer benefit-icon"></i>einen klickbaren Prototypen</strong>
-                  </div>
-                </div>
-              </div>
-              <div class="col-md-6">
-                <div class="card">
-                  <div class="card-body">
-                    <strong><i class="fas fa-wrench benefit-icon"></i>ein kleines internes Tool</strong>
-                  </div>
-                </div>
-              </div>
-              <div class="col-md-6">
-                <div class="card">
-                  <div class="card-body">
-                    <strong><i class="fas fa-flask benefit-icon"></i>eine testbare Produktidee</strong>
-                  </div>
-                </div>
-              </div>
-              <div class="col-md-6">
-                <div class="card">
-                  <div class="card-body">
-                    <strong><i class="fas fa-arrows-rotate benefit-icon"></i>einen wiederverwendbaren Workflow</strong>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <p>Plus: Du weißt danach, wo KI-gestütztes Prototyping funktioniert — und wo nicht. Das spart dir Wochen an Trial-and-Error.</p>
+            <p>Am Ende hast du ein konkretes Ergebnis - einen klickbaren Prototypen, ein kleines internes Tool oder einen Workflow, den du selbst weiterentwickeln kannst.</p>
+            <p>Und du weisst, wo KI-Prototyping funktioniert und wo es scheitert. Das allein spart dir mehr Zeit als der Workshop kostet.</p>
             <div class="text-center mt-3">
               <a href="./kontakt/" class="hero-cta">
                 <i class="fas fa-lightbulb me-2"></i>Eigene Idee besprechen
@@ -782,7 +752,7 @@
                   <div class="card-body step-card">
                     <div class="step-number">1</div>
                     <h6>Verstehen</h6>
-                    <p>Wo KI-Prototyping stark ist, wo seine Grenzen liegen, und welche Fehler du vermeidest</p>
+                    <p>Wo KI-Prototyping funktioniert, wo es scheitert und welche Fehler die meisten am Anfang machen.</p>
                   </div>
                 </div>
               </div>
@@ -790,8 +760,8 @@
                 <div class="card h-100">
                   <div class="card-body step-card">
                     <div class="step-number">2</div>
-                    <h6>Erstes Mini-Projekt</h6>
-                    <p>Du baust ein erstes funktionierendes Ergebnis. Von null auf „klickbar" in unter einer Stunde.</p>
+                    <h6>Erstes Beispiel</h6>
+                    <p>Kein Demo, kein Zuschauen. Du baust etwas von null und tippst selbst.</p>
                   </div>
                 </div>
               </div>
@@ -799,8 +769,8 @@
                 <div class="card h-100">
                   <div class="card-body step-card">
                     <div class="step-number">3</div>
-                    <h6>Debugging</h6>
-                    <p>Echte Fehler beheben, Anforderungen schärfen, Ergebnis verbessern. So wie in der Realität.</p>
+                    <h6>Wenn es nicht klappt</h6>
+                    <p>Fehler gehören dazu. Du lernst, wie du sie einordnest und behebst.</p>
                   </div>
                 </div>
               </div>
@@ -808,8 +778,8 @@
                 <div class="card h-100">
                   <div class="card-body step-card">
                     <div class="step-number">4</div>
-                    <h6>Dein eigenes Projekt</h6>
-                    <p>Deine Idee, dein Prototyp. Oder ein Beispiel gezielt weiterentwickeln.</p>
+                    <h6>Deine Idee</h6>
+                    <p>Du bringst einen eigenen Anwendungsfall mit oder entwickelst das Beispiel weiter.</p>
                   </div>
                 </div>
               </div>
@@ -817,8 +787,8 @@
                 <div class="card h-100">
                   <div class="card-body step-card">
                     <div class="step-number">5</div>
-                    <h6>Review</h6>
-                    <p>Ergebnis prüfen, Feedback einholen, nächste Schritte definieren.</p>
+                    <h6>Was jetzt</h6>
+                    <p>Ergebnis bewerten, offene Fragen klären, nächste Schritte definieren.</p>
                   </div>
                 </div>
               </div>
@@ -866,8 +836,11 @@
                 </div>
               </div>
             </div>
+            <p class="mb-2">
+              Kein Programmierkurs. Keine Softwareausbildung. Kein Versprechen, fertige Produkte zu bauen.
+            </p>
             <p class="mb-0">
-              Stattdessen: schnell ausprobieren, sichtbar machen, testen, lernen und bessere Entscheidungen treffen.
+              Du probierst aus, siehst was funktioniert und weisst danach besser, was in deinem Kontext sinnvoll ist.
             </p>
           </div>
         </div>
@@ -876,21 +849,16 @@
       <div class="accordion-item">
         <h2 class="accordion-header" id="headingFive">
           <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
-            <i class="fas fa-laptop me-2"></i>Was du brauchst — und was nicht
+            <i class="fas fa-laptop me-2"></i>Was du brauchst - und was nicht
           </button>
         </h2>
         <div id="collapseFive" class="accordion-collapse collapse" aria-labelledby="headingFive" data-bs-parent="#workshopAccordion">
           <div class="accordion-body">
-            <ul class="plain-list mb-3" style="padding-left: 1.25rem;">
-              <li>einen Laptop</li>
-              <li>ein Grundverständnis für digitale Tools</li>
-              <li>Offenheit, Dinge auszuprobieren</li>
-            </ul>
-            <p class="text-muted small mb-0">
-              Erfahrung mit KI-Tools ist hilfreich, aber keine Voraussetzung.
+            <p class="mb-2">
+              Du brauchst einen Laptop und solltest dich mit digitalen Tools grundsätzlich auskennen. Programmierkenntnisse sind keine Voraussetzung, Erfahrung mit KI-Tools auch nicht.
             </p>
-            <p class="text-muted small mb-0 mt-2">
-              Du brauchst keine Programmierausbildung, keine tiefen technischen Vorkenntnisse und kein aufwendiges Setup. Beispiele sind vorbereitet, eigene Ideen kannst du direkt einbringen.
+            <p class="mb-0">
+              Beispiele sind vorbereitet. Eigene Ideen kannst du direkt einbringen.
             </p>
           </div>
         </div>
@@ -932,7 +900,7 @@
               und zwischen Fachbereich und Entwicklung vermittelt. Dabei habe ich Teams begleitet, interne Tools auch mit KI-Prototyping effizienter umzusetzen.
             </p>
             <p class="mb-3">
-              Im Workshop zeige ich dir nicht nur die Tools — sondern auch, wo sie scheitern und wie du damit umgehst.
+              Im Workshop zeige ich dir nicht nur die Tools - sondern auch, wo sie scheitern und wie du damit umgehst.
             </p>
 
             <span class="coach-more">
@@ -948,12 +916,15 @@
     </div>
 
     <div class="cta-box mb-4">
-      <h5 class="mb-3" style="font-weight: 700;">In 2 Minuten anfragen – ich sage dir offen, welches Format sinnvoll ist</h5>
+      <h5 class="mb-3" style="font-weight: 700;">Workshop für dein Team abstimmen</h5>
+      <p class="mb-2">
+        Du beschreibst kurz, woran du arbeitest und was du testen willst. Ich melde mich innerhalb von 24 Stunden mit einer Einschätzung: welches Format passt und ob der Workshop für euch das Richtige ist.
+      </p>
       <p class="mb-3">
-        Teile kurz mit, woran du arbeitest. Danach erhältst du eine passende Einschätzung zum Workshop und den nächsten sinnvollen Schritten.
+        Das dauert keine 2 Minuten.
       </p>
       <a href="./kontakt/" class="hero-cta">
-        <i class="fas fa-envelope me-2"></i>Workshop-Fit prüfen
+        <i class="fas fa-envelope me-2"></i>Unverbindlich anfragen
       </a>
     </div>
 


### PR DESCRIPTION
Rewrite all text sections on the landing page per new copy brief:
headline, subheadline, "Warum gerade jetzt", audience blocks,
takeaways, workshop steps, exclusions, requirements, trainer bio,
and final CTA. Replace all em dashes and double hyphens with single
hyphens throughout visible text content.

https://claude.ai/code/session_01Ang62qMNByTVqEUXPpnhV1