### PR TITLE
Update workshop content: neue Texte, Fettungen und Struktur

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,8 +646,9 @@
 
     <div class="overview-box" id="warum-jetzt">
       <h2><i class="fas fa-bolt me-2"></i>Was diesen Workshop anders macht</h2>
-      <p class="mb-2">Die meisten KI-Workshops enden mit Folien und dem Gefühl: „Interessant — aber was mache ich jetzt damit?" Dieser Workshop endet mit einem Prototyp auf deinem Bildschirm.</p>
-      <p class="mb-0">Stell dir vor, du musst deine Idee nicht mehr erklären, sondern klickbar zeigen. Du arbeitest mit echten KI-Tools an einer eigenen Idee. Du probierst aus, machst Fehler, verbesserst — und verstehst genau dadurch, was mit KI-Prototyping in deinem Kontext sinnvoll machbar ist und was nicht.</p>
+      <p class="mb-2">Die meisten KI-Workshops enden mit Folien und dem Gefühl: „Interessant — aber was mache ich jetzt damit?"</p>
+      <p class="mb-2"><strong>Dieser Workshop endet mit einem Prototyp auf deinem Bildschirm.</strong></p>
+      <p class="mb-0">Stell dir vor, du musst deine Idee nicht mehr erklären, sondern klickbar zeigen. Du arbeitest mit echten KI-Tools an einer eigenen Idee. Du probierst aus, machst Fehler, verbesserst — und verstehst genau dadurch, was mit KI-Prototyping in deinem Kontext sinnvoll machbar ist und was nicht. <strong>Idee rein. Prototyp raus.</strong> So einfach ist das Prinzip.</p>
     </div>
 
     <div class="overview-box" id="angebot">
@@ -665,7 +666,7 @@
           <div class="card h-100">
             <div class="card-body">
               <strong>Teilnehmer</strong><br>
-              <small class="text-muted">Einzelpersonen, kleine Teams oder gemischte Gruppen aus Fachbereichen.</small>
+              <small class="text-muted">4–12 Personen · Einzeln, als Team oder bereichsübergreifend</small>
             </div>
           </div>
         </div>
@@ -673,7 +674,7 @@
           <div class="card h-100">
             <div class="card-body">
               <strong>Voraussetzung</strong><br>
-              <small class="text-muted">Laptop + Neugier. Keine Programmierkenntnisse nötig.</small>
+              <small class="text-muted">Ein Laptop, Neugierde und eine Idee. Programmierkenntnisse: nicht nötig.</small>
             </div>
           </div>
         </div>
@@ -700,7 +701,7 @@
       <div class="accordion-item">
         <h2 class="accordion-header" id="headingOne">
           <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-            <i class="fas fa-user-check me-2"></i>Warum du teilnehmen solltest
+            <i class="fas fa-user-check me-2"></i>Was der Workshop für deine Rolle bedeutet
           </button>
         </h2>
         <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#workshopAccordion">
@@ -756,12 +757,12 @@
         </h2>
         <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#workshopAccordion">
           <div class="accordion-body">
-            <ul class="mb-0">
-              <li class="mb-2">Einen präsentierbaren Prototyp — gebaut von dir, basierend auf deiner Idee</li>
-              <li class="mb-2">Praktisches KI-Verständnis — nicht theoretisch, sondern durch eigene Erfahrung</li>
-              <li class="mb-2">Klarheit über Grenzen — du weißt, was realistisch ist und was (noch) nicht funktioniert</li>
-              <li>Einen Plan für danach — konkrete nächste Schritte für dein Projekt</li>
-            </ul>
+            <ol class="mb-0">
+              <li class="mb-2"><strong>Einen präsentierbaren Prototyp</strong> — gebaut von dir, basierend auf deiner Idee. Kein Template, kein Screenshot. Etwas, das du am nächsten Tag zeigen kannst.</li>
+              <li class="mb-2"><strong>Echtes KI-Verständnis</strong> — nicht aus einem Vortrag, sondern aus 4 Stunden eigener Erfahrung. Du weißt, welche Prompts funktionieren und welche nicht.</li>
+              <li class="mb-2"><strong>Klarheit über Grenzen</strong> — du weißt, was heute realistisch ist und wo KI (noch) versagt. Das verhindert teure Fehleinschätzungen.</li>
+              <li><strong>Einen konkreten Plan</strong> — nächste Schritte für dein Projekt, priorisiert und realistisch. Kein vages „man könnte mal...".</li>
+            </ol>
           </div>
         </div>
       </div>
@@ -863,10 +864,13 @@
             <div class="coach-tagline">Digitale Transformation · Projektmanagement · KI-gestütztes Prototyping</div>
 
             <p>
-              Bei RTL Deutschland arbeite ich an der Schnittstelle von Kommunikation, Fachbereich und Entwicklung. Ich habe digitale Systeme aufgebaut, KI-Automatisierungen eingeführt und Teams dabei begleitet, Ideen schneller greifbar zu machen.
+              Bei RTL Deutschland arbeitete ich an der Schnittstelle von Kommunikation, Fachbereich und Entwicklung. Ich habe digitale Systeme aufgebaut, KI-Automatisierungen eingeführt und Teams begleitet, die Ideen schneller greifbar machen wollten.
+            </p>
+            <p>
+              Mein eigener Aha-Moment: Eine Web-App für unsere Familie — To-dos, Notizen, Finanzen — gebaut in einer Woche, besser als jedes Standard-Tool. Das war der Punkt, an dem ich wusste: Das können auch andere lernen.
             </p>
             <p class="mb-3">
-              Mein Aha-Moment mit KI-Prototyping: eine eigene Web-App, die To-dos, Notizen und persönliche Finanzen für unsere Familie besser vereint als Standard-Tools. Genau darum geht es auch im Workshop: aus Ideen greifbare erste Prototypen machen.
+              <strong>Idee rein. Prototyp raus.</strong> Genau darum geht es.
             </p>
 
             <span class="coach-more">
@@ -882,9 +886,9 @@
     </div>
 
     <div class="takeaways-card mb-4">
-      <div class="takeaway-item">Du hast etwas gebaut — keinen Screenshot, keinen Foliensatz, sondern einen funktionierenden Prototyp.</div>
-      <div class="takeaway-item">Du verstehst, warum es funktioniert — und wo die Grenzen liegen.</div>
-      <div class="takeaway-item">Du weißt, was als Nächstes kommt — mit einem konkreten Plan für dein Projekt.</div>
+      <div class="takeaway-item"><strong>Du hast etwas Echtes gebaut.</strong><br>Keinen Screenshot. Keinen Foliensatz. Einen funktionierenden Prototyp, den du morgen zeigen kannst.</div>
+      <div class="takeaway-item"><strong>Du verstehst, warum es funktioniert.</strong><br>Und wo die Grenzen liegen. Du triffst ab jetzt bessere Entscheidungen über KI-Einsatz.</div>
+      <div class="takeaway-item"><strong>Du weißt, was als Nächstes kommt.</strong><br>Mit einem konkreten Plan — nicht mit einem vagen Gefühl.</div>
     </div>
 
     <div class="cta-box mb-4">
@@ -902,6 +906,8 @@
         Keine Warteliste. Keine Newsletter-Anmeldung. Nur eine kurze Nachricht.
       </p>
     </div>
+
+    <p class="text-center mb-4" style="font-size: 1.1rem; font-weight: 600;"><strong>Idee rein. Prototyp raus.</strong></p>
 
   </main>
 


### PR DESCRIPTION
Überarbeitete Abschnitte auf der Landing Page:
- "Was diesen Workshop anders macht" mit eigenem Absatz für Prototyp-Aussage
- Teilnehmer/Voraussetzung Cards aktualisiert
- "Warum du teilnehmen solltest" → "Was der Workshop für deine Rolle bedeutet"
- "Was du konkret mitnimmst" mit fetten Leitsätzen und erweitertem Text
- "Wer dich begleitet" Bio neu formuliert (Vergangenheitsform, neuer Aha-Moment)
- "Drei Dinge, die bleiben" mit fetten Leitsätzen und Erklärungstext
- "Idee rein. Prototyp raus." als Abschluss vor dem Footer

https://claude.ai/code/session_01741WBMPsSJRmdMC2xR7vaE