### PR TITLE
fix: Workshop-Karten von 3+1 auf 2×2 Raster ändern

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,7 +636,7 @@
     <div class="overview-box" id="angebot">
       <h2><i class="fas fa-binoculars me-2"></i>Dein Workshop auf einen Blick</h2>
       <div class="row g-3 overview-grid">
-        <div class="col-md-4">
+        <div class="col-md-6">
           <div class="card h-100">
             <div class="card-body">
               <strong>Format</strong><br>
@@ -644,7 +644,7 @@
             </div>
           </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-6">
           <div class="card h-100">
             <div class="card-body">
               <strong>Teilnehmer</strong><br>
@@ -652,7 +652,7 @@
             </div>
           </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-6">
           <div class="card h-100">
             <div class="card-body">
               <strong>Voraussetzung</strong><br>
@@ -660,7 +660,7 @@
             </div>
           </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-6">
           <div class="card h-100">
             <div class="card-body">
               <strong>Ergebnis</strong><br>


### PR DESCRIPTION
col-md-4 → col-md-6 für die 4 "Workshop auf einen Blick"-Karten,
damit sie auf Desktop gleichmäßig als 2×2 Raster erscheinen.

https://claude.ai/code/session_01TaHPrjHWFixEWKL1ot85J4