### PR TITLE
feat(design): implement Quick Wins #1–#7 from design briefing

### DIFF
--- a/css/nav.css
+++ b/css/nav.css
@@ -158,14 +158,24 @@ body {
   font-weight: 600;
   border-radius: var(--border-radius-button, 6px);
   text-decoration: none;
-  transition: opacity var(--transition-fast, 0.2s ease);
+  transition: transform var(--transition-fast, 0.2s ease),
+              box-shadow var(--transition-fast, 0.2s ease),
+              background-color var(--transition-fast, 0.2s ease);
   white-space: nowrap;
 }
 
-.site-nav-cta:hover {
-  opacity: 0.85;
+.site-nav-cta:hover,
+.site-nav-cta:focus-visible {
+  background: var(--secondary-color, #3D5A8C);
   color: #fff !important;
   text-decoration: none;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(91, 139, 214, 0.35);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-nav-cta:hover,
+  .site-nav-cta:focus-visible { transform: none; }
 }
 
 /* ── Responsive ──────────────────────────────────── */

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -27,10 +27,24 @@
   --warning-color:      #D4A55B;
   --info-color:         #6BB8D4;
   --bg-page:            #EEF2F7;
-  --bg-card:            rgba(255, 255, 255, 0.92);
+  --bg-card:            rgba(255, 255, 255, 0.78);
+  --bg-card-solid:      #FFFFFF;
   --text-primary:       #2D3748;
   --text-muted:         #7A8599;
   --border-color:       #D4DCE8;
+
+  /* ── Typography Weights & Tracking ───────────────── */
+  --font-weight-regular:  400;
+  --font-weight-medium:   500;
+  --font-weight-semibold: 600;
+  --font-weight-bold:     700;
+  --font-weight-black:    800;
+  --tracking-display:    -0.04em;
+  --tracking-tight:      -0.02em;
+  --tracking-label:       0.15em;
+
+  /* ── Glassmorphism ───────────────────────────────── */
+  --card-blur:          blur(16px) saturate(1.4);
 
   /* ── Border Radii ────────────────────────────────── */
   --border-radius-card:   10px;
@@ -90,6 +104,8 @@ body {
 
 .card {
   background: var(--bg-card);
+  backdrop-filter: var(--card-blur);
+  -webkit-backdrop-filter: var(--card-blur);
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius-card);
 }
@@ -105,6 +121,56 @@ body {
 
 .section-header:first-child { margin-top: 0; }
 
+/*
+ * Numbered section header — auto-numbered eyebrow + larger title.
+ * Usage:
+ *   <div class="numbered-sections">
+ *     <div class="section-header numbered">
+ *       <span class="section-eyebrow">Was du mitnimmst</span>
+ *       <h2 class="section-title-lg">…</h2>
+ *     </div>
+ *   </div>
+ * The "01 — " prefix is generated via CSS counters on .numbered-sections.
+ */
+.numbered-sections { counter-reset: section-num; }
+
+.section-header.numbered {
+  counter-increment: section-num;
+  border-left: none;
+  padding: 0;
+  background: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border-radius: 0;
+  margin-bottom: var(--space-5);
+}
+
+.section-header.numbered .section-eyebrow {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: var(--space-2);
+}
+
+.section-header.numbered .section-eyebrow::before {
+  content: counter(section-num, decimal-leading-zero) "  —  ";
+  color: var(--primary-color);
+  font-weight: var(--font-weight-bold);
+}
+
+.section-header.numbered .section-title-lg,
+.section-header.numbered h2 {
+  font-size: 1.6rem;
+  font-weight: var(--font-weight-black);
+  letter-spacing: var(--tracking-tight);
+  line-height: 1.15;
+  color: var(--text-primary);
+  margin: 0;
+}
+
 /* ── Page Wrapper ────────────────────────────────── */
 
 .page-wrapper {
@@ -117,6 +183,17 @@ body {
   body { background-attachment: scroll; }
   .card {
     background: rgba(255, 255, 255, 0.96);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -83,11 +83,36 @@
       text-align: center;
       border-radius: 0 0 var(--border-radius-card) var(--border-radius-card);
       margin-bottom: 1.25rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    /*
+     * Hero code texture — monospace character grid at low opacity.
+     * Pure CSS, no extra DOM, no images. Disabled on mobile + reduced-motion.
+     */
+    .hero-section::before {
+      content: "{ } < > / * = ; ( ) [ ] _ + - $ # & | ! ? . ,";
+      position: absolute;
+      inset: -10%;
+      font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 1.15rem;
+      letter-spacing: 0.4em;
+      line-height: 2.2;
+      color: #ffffff;
+      opacity: 0.06;
+      white-space: pre-wrap;
+      word-break: break-all;
+      pointer-events: none;
+      transform: rotate(-12deg);
+      mix-blend-mode: overlay;
     }
 
     .hero-inner {
       max-width: 860px;
       margin: 0 auto;
+      position: relative;
+      z-index: 1;
     }
 
     .hero-badge {
@@ -100,10 +125,10 @@
 
     .hero-section h1 {
       color: #ffffff;
-      font-weight: 800;
-      font-size: clamp(2rem, 4.2vw, 3rem);
-      line-height: 1.08;
-      letter-spacing: -0.02em;
+      font-weight: var(--font-weight-black);
+      font-size: clamp(2rem, 4.6vw, 3.25rem);
+      line-height: 1.05;
+      letter-spacing: var(--tracking-display);
       max-width: 900px;
       margin: 0 auto;
       text-shadow: 0 2px 6px rgba(0, 0, 0, 0.14);
@@ -477,6 +502,12 @@
         backdrop-filter: none;
         -webkit-backdrop-filter: none;
       }
+
+      .hero-section::before { display: none; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .hero-section::before { display: none; }
     }
 
     @media (max-width: 768px) {
@@ -622,7 +653,7 @@
     </div>
   </div>
 
-  <main class="container-fluid py-3" style="max-width: 920px; margin: 0 auto;">
+  <main class="container-fluid py-3 numbered-sections" style="max-width: 920px; margin: 0 auto;">
 
     <div class="overview-box" id="warum-jetzt">
       <h2><i class="fas fa-bolt me-2"></i>Was diesen Workshop anders macht</h2>
@@ -837,8 +868,9 @@
 
     </div>
 
-    <div class="section-header mt-4">
-      <h5><i class="fas fa-user-tie me-2"></i>Wer dich begleitet</h5>
+    <div class="section-header numbered mt-4">
+      <span class="section-eyebrow">Wer dich begleitet</span>
+      <h2 class="section-title-lg">Dein Coach</h2>
     </div>
 
     <a class="coach-link-card mb-4" href="https://fauteck.github.io/vibecoding-academy/ueber-mich/">
@@ -884,8 +916,9 @@
       </div>
     </a>
 
-    <div class="section-header mt-4">
-      <h5><i class="fas fa-lightbulb me-2"></i>Drei Dinge, die bleiben</h5>
+    <div class="section-header numbered mt-4">
+      <span class="section-eyebrow">Was du mitnimmst</span>
+      <h2 class="section-title-lg">Drei Dinge, die bleiben.</h2>
     </div>
 
     <div class="row g-3 mb-4">

--- a/kontakt/index.html
+++ b/kontakt/index.html
@@ -131,11 +131,20 @@
       text-decoration: none;
       font-weight: 600;
       font-size: 0.95rem;
-      transition: opacity 0.2s;
+      transition: transform var(--transition-fast),
+                  box-shadow var(--transition-fast),
+                  background-color var(--transition-fast);
     }
-    .cta-btn:hover {
-      opacity: 0.85;
+    .cta-btn:hover,
+    .cta-btn:focus-visible {
+      background: var(--secondary-color);
       color: #fff;
+      transform: translateY(-2px);
+      box-shadow: 0 6px 20px rgba(91, 139, 214, 0.35);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .cta-btn:hover,
+      .cta-btn:focus-visible { transform: none; }
     }
 
     /* ── Contact Form ──────────────────────────────── */

--- a/projekte/index.html
+++ b/projekte/index.html
@@ -73,6 +73,28 @@
       box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     }
 
+    /* ── Project Tile Icon ─────────────────────────────────── */
+    .tile-icon {
+      width: 64px;
+      height: 64px;
+      margin: 0 auto 0.75rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 14px;
+      background: linear-gradient(135deg, rgba(91,139,214,0.12), rgba(107,184,212,0.18));
+      color: var(--primary-color);
+      font-size: 1.75rem;
+      transition: transform 0.2s ease, background 0.2s ease;
+    }
+    a.card:hover .tile-icon {
+      transform: scale(1.05);
+      background: linear-gradient(135deg, rgba(91,139,214,0.22), rgba(107,184,212,0.28));
+    }
+    @media (prefers-reduced-motion: reduce) {
+      a.card:hover .tile-icon { transform: none; }
+    }
+
 
     /* ── Hero ──────────────────────────────────────────────── */
     .hero-section {
@@ -147,19 +169,20 @@
     </div>
   </div>
 
-  <main class="container-fluid py-3" style="max-width: 900px; margin: 0 auto;">
+  <main class="container-fluid py-3 numbered-sections" style="max-width: 900px; margin: 0 auto;">
 
     <!-- Ergebnisse -->
-    <div class="section-header" id="ergebnisse">
-      <h5><i class="fas fa-rocket me-2"></i>Ergebnisse</h5>
-      <p class="text-muted small mb-0 mt-1">Fertige Projekte aus dem Workshop zum Ausprobieren</p>
+    <div class="section-header numbered" id="ergebnisse">
+      <span class="section-eyebrow">Ergebnisse</span>
+      <h2 class="section-title-lg">Fertige Projekte aus dem Workshop</h2>
+      <p class="text-muted small mb-0 mt-2">Zum Ausprobieren — alle direkt im Browser, ohne Installation.</p>
     </div>
 
     <div class="row g-3 mb-4">
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="../apps/pong/">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">🏓</div>
+            <div class="tile-icon"><i class="fas fa-table-tennis-paddle-ball" aria-hidden="true"></i></div>
             <h6 class="card-title">Pong</h6>
             <p class="card-text text-muted small">Klassisches Pong-Spiel: Spieler gegen KI</p>
           </div>
@@ -168,7 +191,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="../apps/gta/">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">🚗</div>
+            <div class="tile-icon"><i class="fas fa-car-side" aria-hidden="true"></i></div>
             <h6 class="card-title">Grand Thomas Auto 6</h6>
             <p class="card-text text-muted small">GTA-Parodie im RTL-Sendezentrum</p>
           </div>
@@ -177,7 +200,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="../apps/wochenendplanung/">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">📅</div>
+            <div class="tile-icon"><i class="fas fa-calendar-week" aria-hidden="true"></i></div>
             <h6 class="card-title">Wochenendplanung</h6>
             <p class="card-text text-muted small">Wochenenddienst-Planung und Übersicht</p>
           </div>
@@ -186,7 +209,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="../apps/blog/">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">📰</div>
+            <div class="tile-icon"><i class="fas fa-newspaper" aria-hidden="true"></i></div>
             <h6 class="card-title">KI-Blog</h6>
             <p class="card-text text-muted small">Redaktionsblog mit KI-Unterstützung erstellt</p>
           </div>
@@ -195,7 +218,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="../kontakt/" style="border: 2px dashed var(--primary-color);">
           <div class="card-body text-center d-flex flex-column justify-content-center">
-            <div class="fs-1 mb-2">🚀</div>
+            <div class="tile-icon"><i class="fas fa-rocket" aria-hidden="true"></i></div>
             <h6 class="card-title">Dein Anwendungsfall</h6>
             <p class="card-text small" style="color: var(--text-muted);">Im Workshop entsteht ein erster Prototyp für euren echten Use Case</p>
             <span class="mt-auto" style="color: var(--primary-color); font-weight: 600; font-size: 0.9rem;">
@@ -207,16 +230,17 @@
     </div>
 
     <!-- Ideen & Konzepte -->
-    <div class="section-header mt-4" id="ideen">
-      <h5><i class="fas fa-lightbulb me-2"></i>Ideen &amp; Konzepte</h5>
-      <p class="text-muted small mb-0 mt-1">Konzeptvorlagen als Startpunkt für eigene Projekte</p>
+    <div class="section-header numbered mt-5" id="ideen">
+      <span class="section-eyebrow">Ideen &amp; Konzepte</span>
+      <h2 class="section-title-lg">Vorlagen für eigene Projekte</h2>
+      <p class="text-muted small mb-0 mt-2">Konzeptvorlagen als Startpunkt — im Workshop bauen wir gemeinsam daraus etwas Lauffähiges.</p>
     </div>
 
     <div class="row g-3 mb-4">
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=flappybird.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">🐦</div>
+            <div class="tile-icon"><i class="fas fa-feather" aria-hidden="true"></i></div>
             <h6 class="card-title">Flappy Bird</h6>
             <p class="card-text text-muted small">Fliege durch die Lücken zwischen den Röhren</p>
           </div>
@@ -225,7 +249,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=memory.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">🃏</div>
+            <div class="tile-icon"><i class="fas fa-clone" aria-hidden="true"></i></div>
             <h6 class="card-title">Memory</h6>
             <p class="card-text text-muted small">Finde alle passenden Kartenpaare</p>
           </div>
@@ -234,7 +258,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=minesweeper.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">💣</div>
+            <div class="tile-icon"><i class="fas fa-bomb" aria-hidden="true"></i></div>
             <h6 class="card-title">Minesweeper</h6>
             <p class="card-text text-muted small">Decke das Feld auf, ohne eine Mine zu treffen</p>
           </div>
@@ -243,7 +267,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=pong.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">🏓</div>
+            <div class="tile-icon"><i class="fas fa-table-tennis-paddle-ball" aria-hidden="true"></i></div>
             <h6 class="card-title">Pong</h6>
             <p class="card-text text-muted small">Klassisches Pong-Spiel: Spieler gegen KI</p>
           </div>
@@ -252,7 +276,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=snake.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">🐍</div>
+            <div class="tile-icon"><i class="fas fa-staff-snake" aria-hidden="true"></i></div>
             <h6 class="card-title">Snake</h6>
             <p class="card-text text-muted small">Sammle Futter und werde immer länger</p>
           </div>
@@ -261,7 +285,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=solitaire.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">🂡</div>
+            <div class="tile-icon"><i class="fas fa-spade" aria-hidden="true"></i></div>
             <h6 class="card-title">Solitär</h6>
             <p class="card-text text-muted small">Klassisches Klondike-Kartenspiel</p>
           </div>
@@ -270,7 +294,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=sudoku.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">🔢</div>
+            <div class="tile-icon"><i class="fas fa-table-cells" aria-hidden="true"></i></div>
             <h6 class="card-title">Sudoku</h6>
             <p class="card-text text-muted small">Fülle das 9x9-Gitter mit den richtigen Zahlen</p>
           </div>
@@ -279,7 +303,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=tetris.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">🧱</div>
+            <div class="tile-icon"><i class="fas fa-shapes" aria-hidden="true"></i></div>
             <h6 class="card-title">Tetris</h6>
             <p class="card-text text-muted small">Stapele fallende Blöcke zu vollen Reihen</p>
           </div>
@@ -288,7 +312,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=tictactoe.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">❌</div>
+            <div class="tile-icon"><i class="fas fa-xmark" aria-hidden="true"></i></div>
             <h6 class="card-title">Tic-Tac-Toe</h6>
             <p class="card-text text-muted small">Drei in einer Reihe gewinnt</p>
           </div>
@@ -297,7 +321,7 @@
       <div class="col-md-4 col-sm-6">
         <a class="card text-decoration-none h-100" href="viewer.html?file=haushaltsbuch.md">
           <div class="card-body text-center">
-            <div class="fs-1 mb-2">📒</div>
+            <div class="tile-icon"><i class="fas fa-book" aria-hidden="true"></i></div>
             <h6 class="card-title">Haushaltsbuch</h6>
             <p class="card-text text-muted small">Einfache Eingaben-/Ausgaben-App für den Haushalt</p>
           </div>

--- a/ueber-mich/index.html
+++ b/ueber-mich/index.html
@@ -45,24 +45,43 @@
       }
     }
 
-    /* ── Avatar ──────────────────────────────────────── */
+    /* ── Avatar (Polaroid) ───────────────────────────── */
     .avatar-wrapper {
-      width: 200px;
-      height: 200px;
-      border-radius: 50%;
+      width: 320px;
+      height: 320px;
       overflow: hidden;
-      border: 4px solid var(--primary-color);
-      background: var(--bg-page);
+      background: #fff;
+      padding: 14px 14px 56px;
       display: flex;
       align-items: center;
       justify-content: center;
-      margin: 0 auto 1.5rem;
-      box-shadow: 0 4px 20px rgba(91, 139, 214, 0.25);
+      margin: 0 auto 2rem;
+      box-shadow: 0 18px 40px rgba(61, 90, 140, 0.22),
+                  0 2px 6px rgba(0, 0, 0, 0.08);
+      transform: rotate(-2deg);
+      transition: transform 0.3s ease;
+      border-radius: 4px;
+    }
+    .avatar-wrapper:hover {
+      transform: rotate(0deg) scale(1.02);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .avatar-wrapper { transform: none; }
+      .avatar-wrapper:hover { transform: none; }
     }
     .avatar-wrapper img {
       width: 100%;
       height: 100%;
       object-fit: cover;
+      border-radius: 2px;
+    }
+    @media (max-width: 600px) {
+      .avatar-wrapper {
+        width: 240px;
+        height: 240px;
+        padding: 10px 10px 42px;
+        transform: rotate(-1.5deg);
+      }
     }
     .avatar-placeholder {
       font-size: 5rem;
@@ -221,12 +240,12 @@
                     srcset="../images/niklas-fauteck-200w.avif 200w,
                            ../images/niklas-fauteck-300w.avif 300w,
                            ../images/niklas-fauteck-400w.avif 400w"
-                    sizes="200px">
+                    sizes="(max-width: 600px) 220px, 300px">
             <source type="image/webp"
                     srcset="../images/niklas-fauteck-200w.webp 200w,
                            ../images/niklas-fauteck-300w.webp 300w,
                            ../images/niklas-fauteck-400w.webp 400w"
-                    sizes="200px">
+                    sizes="(max-width: 600px) 220px, 300px">
             <img src="../images/niklas-fauteck-300w.jpg" alt="Niklas Fauteck"
                  loading="lazy" decoding="async" width="300" height="300"
                  fetchpriority="low">


### PR DESCRIPTION
- #1 Hero code texture (CSS pseudo-element, monospace at low opacity, disabled on mobile/reduced-motion).
- #2 Replace 13 emoji project tiles with Font Awesome icons in a tinted gradient frame (consistent with the rest of the site).
- #3 Numbered section header system — `.section-header.numbered` with auto-numbering eyebrow ("01 — …") + larger 800-weight title. Applied on landing + projekte pages; old border-left variant kept as fallback.
- #4 Stronger glassmorphism — `--bg-card` to 0.78 alpha, new `--card-blur: blur(16px) saturate(1.4)` token; mobile keeps solid.
- #5 Typography tokens — `--font-weight-black: 800`, `--tracking-display: -0.04em`, `--tracking-tight: -0.02em`. Applied to landing hero h1.
- #6 Coach avatar promoted to 320px polaroid frame with -2deg tilt (240px on small mobile); reduced-motion aware.
- #7 CTA hover replaces `opacity: 0.85` with translateY + soft blue shadow + secondary-color shift; reduced-motion aware. Applied to .site-nav-cta and kontakt .cta-btn.

Global prefers-reduced-motion override added to tokens.css.