### PR TITLE
feat(design): extend tokens, add type helpers, add SKILL.md

### DIFF
--- a/css/tokens.css
+++ b/css/tokens.css
@@ -78,6 +78,48 @@
   /* ── Gradient Presets ────────────────────────────── */
   --gradient-nav:  linear-gradient(135deg, #5B8BD6, #3D5A8C);
   --gradient-hero: linear-gradient(135deg, rgba(61, 90, 140, 0.22), rgba(91, 139, 214, 0.15));
+
+  /* ── Typography Scale (added from design system) ─── */
+  --font-sans:         'IBM Plex Sans', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --font-mono:         'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  --font-size-xs:      0.75rem;   /* 12px   — nav subtitle, labels */
+  --font-size-sm:      0.85rem;   /* 13.6px — footer, CTA, small */
+  --font-size-nav:     0.9rem;    /* 14.4px — nav links */
+  --font-size-base:    1rem;      /* 16px   — body */
+  --font-size-md:      1.1rem;    /* 17.6px — emphasized body, lead */
+  --font-size-lg:      1.5rem;    /* 24px   — brand */
+  --font-size-xl:      1.8rem;    /* 28.8px — page title */
+  --font-size-display: clamp(2rem, 4.2vw, 3rem);
+
+  --line-height-tight: 1.08;
+  --line-height-base:  1.5;
+  --line-height-loose: 1.75;
+
+  --tracking-wide:     0.05em;    /* uppercase nav subtitles */
+
+  /* ── Semantic Foreground / Background Aliases ────── */
+  --fg1:        var(--text-primary);
+  --fg2:        var(--text-muted);
+  --fg-brand:   var(--secondary-color);
+  --fg-accent:  var(--primary-color);
+  --bg1:        var(--bg-page);
+  --bg2:        var(--bg-card);
+
+  /* ── Extra Surfaces / On-Dark Text ───────────────── */
+  --bg-card-mobile:       rgba(255, 255, 255, 0.88);
+  --bg-white:             #FFFFFF;
+  --text-on-dark:         rgba(255, 255, 255, 0.7);
+  --text-on-dark-strong:  rgba(255, 255, 255, 0.95);
+
+  /* ── Extra Shadow / Gradient ─────────────────────── */
+  --shadow-focus-ring: 0 0 0 3px rgba(91, 139, 214, 0.15);
+  --gradient-cta-soft: linear-gradient(135deg, rgba(91, 139, 214, 0.12), rgba(92, 198, 167, 0.12));
+
+  /* ── Radius Aliases (shorter names from design system) ── */
+  --radius-card:   var(--border-radius-card);
+  --radius-button: var(--border-radius-button);
+  --radius-pill:   var(--border-radius-pill);
 }
 
 /* ── Reset ───────────────────────────────────────── */

--- a/css/typography.css
+++ b/css/typography.css
@@ -1,0 +1,79 @@
+/* ──────────────────────────────────────────────────────────────
+   Vibecoding Academy — Semantic Type Helpers
+   Apply these classes (or copy the rules) instead of restyling
+   each h1/h2 from scratch.
+   Source: design-system bundle (colors_and_type.css).
+   Depends on tokens.css for font-family, font-size, color, weight,
+   tracking and line-height variables.
+   ────────────────────────────────────────────────────────────── */
+
+.t-display,
+.hero h1 {
+  font-size: var(--font-size-display);
+  font-weight: var(--font-weight-black);
+  line-height: var(--line-height-tight);
+  letter-spacing: var(--tracking-display);
+  color: #fff;
+}
+
+.t-h1 { font-size: var(--font-size-xl); font-weight: var(--font-weight-bold); color: var(--fg1); }
+.t-h2 { font-size: 1.4rem;              font-weight: var(--font-weight-bold); color: var(--fg1); }
+.t-h3 { font-size: var(--font-size-md); font-weight: var(--font-weight-bold); color: var(--fg-brand); }
+
+.t-section-title {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  color: var(--fg-brand);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.t-brand-name {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-brand);
+}
+
+.t-brand-subtitle {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  color: var(--fg2);
+}
+
+.t-section-label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--fg-accent);
+}
+
+.t-lead {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--line-height-loose);
+  color: var(--fg1);
+}
+
+.t-body {
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-loose);
+  color: var(--fg1);
+}
+
+.t-muted {
+  font-size: var(--font-size-sm);
+  color: var(--fg2);
+}
+
+.t-mono {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: rgba(91, 139, 214, 0.08);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,6 +13,7 @@
 | [DESIGN.md](../DESIGN.md) | Design system — tokens, rationale, accessibility, components |
 | [docs/architektur.md](architektur.md) | Shared components, path resolution, CSS chain, design tokens |
 | [docs/arbeitsablaeufe.md](arbeitsablaeufe.md) | Step-by-step guides for common tasks |
+| [docs/SKILL.md](SKILL.md) | AI-skill manifest — brand quick-reference, token & helper-class entry points |
 | [README.md](../README.md) | Project overview, features, tech stack |
 
 ---
@@ -22,10 +23,12 @@
 | Absolute Path | Purpose | Lines |
 |---------------|---------|-------|
 | `/home/user/vibecoding-academy/js/components.js` | Navigation & footer injection (all pages) | 90 |
-| `/home/user/vibecoding-academy/css/tokens.css` | Design tokens, CSS reset, base styles | ~110 |
+| `/home/user/vibecoding-academy/css/tokens.css` | Design tokens, CSS reset, base styles | ~250 |
+| `/home/user/vibecoding-academy/css/typography.css` | Semantic `.t-*` type helper classes (opt-in per page) | ~80 |
 | `/home/user/vibecoding-academy/css/nav.css` | Navigation styles (desktop + mobile) | 193 |
 | `/home/user/vibecoding-academy/css/footer.css` | Footer styles | 19 |
 | `/home/user/vibecoding-academy/DESIGN.md` | Design system specification | — |
+| `/home/user/vibecoding-academy/docs/SKILL.md` | AI-skill manifest (brand + token entry points) | — |
 | `/home/user/vibecoding-academy/index.html` | Landing page | 959 |
 
 ---
@@ -47,6 +50,7 @@
 │
 ├── css/                                # Shared stylesheets
 │   ├── tokens.css                      #   Design tokens + reset
+│   ├── typography.css                  #   Opt-in .t-* type helpers
 │   ├── nav.css                         #   Navigation (desktop + mobile)
 │   └── footer.css                      #   Footer
 │
@@ -98,5 +102,6 @@
 └── docs/                               # LLM-optimised documentation
     ├── INDEX.md                        #   ← You are here
     ├── architektur.md                  #   Architecture & components
-    └── arbeitsablaeufe.md              #   Workflows & tasks
+    ├── arbeitsablaeufe.md              #   Workflows & tasks
+    └── SKILL.md                        #   AI-skill manifest
 ```

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: vibecoding-academy-design
+description: Use this skill to generate well-branded interfaces and assets for Vibecoding Academy mit Niklas Fauteck — production code or throwaway prototypes/mocks. Contains essential design guidelines, color & type tokens, fonts, vendored assets, and reusable type helpers.
+user-invocable: true
+---
+
+Read `DESIGN.md` (full design system spec), `css/tokens.css` (CSS variables), `css/typography.css` (`.t-*` semantic type helpers), and the existing pages under `apps/`, `wiki/`, `kontakt/`, `ueber-mich/`, `projekte/` for usage examples.
+
+When making **production code** changes, follow `CLAUDE.md` strictly: vanilla HTML/CSS/JS only, no build tools, no CDNs, vendored assets in `/vendor`, the canonical CSP meta-tag on every new page, and the design tokens from `css/tokens.css`.
+
+When making **throwaway prototypes / mocks** for design review, you may inline assets and skip CSP, but stay inside the brand: IBM Plex Sans only, single blue family (`#5B8BD6` primary, `#3D5A8C` secondary), Font Awesome 6.4.2 icons (no Lucide / Heroicons), no emoji in chrome.
+
+If the user invokes this skill without specific guidance, ask what they want to build, then act as an expert designer who outputs HTML artifacts _or_ production code — whichever fits.
+
+Brand quick-reference:
+
+- German-language ("du" form), single typeface (IBM Plex Sans), single blue family.
+- Mantra: „Idee rein. Prototyp raus."
+- H1: „Erst bauen. Dann wissen, was wirklich geht."
+- No emoji in chrome; emoji only as project-tile markers on `projekte/index.html`.
+- Cards: `border-radius: 10px`, 1px `--border-color`, glassmorphism on desktop only (mobile breakpoint `991.98px` disables `backdrop-filter`).
+- CTA hover: `translateY(-1px)` + soft brand-blue shadow, NOT `opacity: 0.85`.
+- Section headers (numbered): use `.numbered-sections` + `.section-header.numbered` with `.section-eyebrow` + `.section-title-lg` for the auto-generated `01 — ` prefix.
+
+Token entry points (from `css/tokens.css`):
+
+- Color: `--primary-color`, `--secondary-color`, `--success-color`, `--danger-color`, `--warning-color`, `--info-color`, `--bg-page`, `--bg-card`, `--text-primary`, `--text-muted`, `--border-color`.
+- Semantic aliases: `--fg1`, `--fg2`, `--fg-brand`, `--fg-accent`, `--bg1`, `--bg2`.
+- Typography: `--font-sans`, `--font-mono`, `--font-size-xs|sm|nav|base|md|lg|xl|display`, `--line-height-tight|base|loose`.
+- Weights & tracking: `--font-weight-regular|medium|semibold|bold|black`, `--tracking-display|tight|label|wide`.
+- Surfaces: `--shadow-sm|md|lg`, `--shadow-focus-ring`, `--card-blur`, `--bg-card-mobile`, `--bg-white`, `--text-on-dark[-strong]`.
+- Radii: `--border-radius-card|button|pill` (canonical) or short aliases `--radius-card|button|pill`.
+- Gradients: `--gradient-nav`, `--gradient-hero`, `--gradient-cta-soft`.
+- Spacing: `--space-1` … `--space-7` (4 px grid).
+
+Type-helper classes (from `css/typography.css`, opt-in per page via `<link rel="stylesheet" href=".../css/typography.css">`):
+
+- `.t-display`, `.t-h1`, `.t-h2`, `.t-h3`, `.t-section-title`, `.t-section-label`, `.t-brand-name`, `.t-brand-subtitle`, `.t-lead`, `.t-body`, `.t-muted`, `.t-mono`.
+
+Path resolution: each page sets `<html data-depth="0|1|2">` so `js/components.js` injects nav/footer with correct relative paths. Match `data-depth` to the folder depth of the file.


### PR DESCRIPTION
Adds the design-system layer that was missing from the bundle:
- Typography scale, line-heights, font-mono, semantic fg/bg aliases,
  on-dark text, focus ring, soft CTA gradient, radius aliases
- New css/typography.css with opt-in .t-* helper classes
- docs/SKILL.md as agent skill manifest with brand quick-reference
- docs/INDEX.md updated to reference both new files

All additions are non-breaking: existing token names and values are
unchanged, and no HTML pages need to be modified.