### PR TITLE
fix(apps): stack footer below game canvas in pong and gta

### DIFF
--- a/apps/gta/index.html
+++ b/apps/gta/index.html
@@ -29,7 +29,7 @@
     @font-face { font-family: 'JetBrains Mono'; src: url('fonts/JetBrainsMono-ExtraBold.woff2') format('woff2'); font-weight: 800; font-style: normal; font-display: swap; }
 
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: system-ui, sans-serif; background: #0a0a0a; display: flex; justify-content: center; align-items: flex-start; min-height: 100vh; padding-top: 48px; overflow: hidden; }
+    body { font-family: system-ui, sans-serif; background: #0a0a0a; display: flex; flex-direction: column; justify-content: flex-start; align-items: center; min-height: 100vh; padding-top: 48px; overflow: hidden; }
 
     @media (max-width: 991.98px) {
       .gta-controls { bottom: 80px; }

--- a/apps/pong/index.html
+++ b/apps/pong/index.html
@@ -25,7 +25,7 @@
   <link rel="stylesheet" href="../../css/footer.css">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: system-ui, sans-serif; background: #111; display: flex; justify-content: center; align-items: center; min-height: 100vh; padding-top: 48px; }
+    body { font-family: system-ui, sans-serif; background: #111; display: flex; flex-direction: column; justify-content: center; align-items: center; min-height: 100vh; padding-top: 48px; }
 
     #game { width: 420px; height: 500px; position: relative; }
     .pong-wrap { display:flex; flex-direction:column; align-items:center; height:100%; background:#111; padding:8px; box-sizing:border-box; }


### PR DESCRIPTION
Body used display:flex without a direction, so the injected <footer> rendered as a sibling column next to the game canvas. Adding flex-direction: column keeps nav at the top and prevents the footer from appearing as a side panel.