### PR TITLE
fix(apps): use global site navigation in pong, gta, and wochenendplanung

### DIFF
--- a/apps/gta/index.html
+++ b/apps/gta/index.html
@@ -29,13 +29,13 @@
     @font-face { font-family: 'JetBrains Mono'; src: url('fonts/JetBrainsMono-ExtraBold.woff2') format('woff2'); font-weight: 800; font-style: normal; font-display: swap; }
 
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: system-ui, sans-serif; background: #0a0a0a; display: flex; flex-direction: column; justify-content: flex-start; align-items: center; min-height: 100vh; padding-top: 48px; overflow: hidden; }
+    body { font-family: system-ui, sans-serif; background: #0a0a0a; display: flex; flex-direction: column; justify-content: flex-start; align-items: center; min-height: 100vh; overflow: hidden; }
 
     @media (max-width: 991.98px) {
       .gta-controls { bottom: 80px; }
     }
 
-    #game { width: 100vw; height: calc(100vh - 48px); display: flex; align-items: center; justify-content: center; }
+    #game { width: 100vw; height: calc(100vh - 4.5rem); display: flex; align-items: center; justify-content: center; }
     .gta-game {
       display: flex; flex-direction: column; align-items: center; justify-content: center;
       background: #0a0a0a; width: 100%; height: 100%; position: relative;
@@ -190,79 +190,7 @@
   </style>
 </head>
 <body>
-  <!-- Desktop Navbar (>992px) -->
-  <nav class="navbar navbar-expand d-none d-lg-flex">
-    <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
-      <a class="navbar-brand" href="../../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
-      </a>
-      <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../../#workshop">Workshop</a>
-        <a class="navbar-link" href="../../wiki/">Wiki</a>
-        <div class="dropdown">
-          <a class="navbar-link dropdown-toggle active" href="../../projekte/" role="button" data-bs-toggle="dropdown" aria-expanded="false">Projekte</a>
-          <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="../../apps/pong/">Pong</a></li>
-            <li><a class="dropdown-item active" href="../../apps/gta/">Grand Thomas Auto 6</a></li>
-            <li><a class="dropdown-item" href="../../apps/wochenendplanung/">Wochenendplanung</a></li>
-            <li><a class="dropdown-item" href="../../apps/blog/">KI-Blog</a></li>
-          </ul>
-        </div>
-        <a class="navbar-link" href="../../ueber-mich/">Coach</a>
-      </div>
-    </div>
-  </nav>
-
-  <!-- Mobile Top Bar (<=992px) -->
-  <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
-    <a class="mobile-topbar-brand" href="../../">
-      <i class="fas fa-code me-1"></i> Vibecoding Academy
-    </a>
-    <span style="width: 32px;"></span>
-  </div>
-
-  <!-- Mobile Offcanvas: Projekte -->
-  <div class="offcanvas offcanvas-bottom nav-sheet" tabindex="-1" id="projekteSheet" style="height: auto; max-height: 70vh;">
-    <div class="offcanvas-header">
-      <h5 class="offcanvas-title"><i class="fas fa-rocket me-2"></i>Projekte</h5>
-      <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas"></button>
-    </div>
-    <div class="offcanvas-body p-0">
-      <div class="list-group list-group-flush">
-        <a href="../../apps/pong/" class="list-group-item list-group-item-action">Pong</a>
-        <a href="../../apps/gta/" class="list-group-item list-group-item-action active">Grand Thomas Auto 6</a>
-        <a href="../../apps/wochenendplanung/" class="list-group-item list-group-item-action">Wochenendplanung</a>
-        <a href="../../apps/blog/" class="list-group-item list-group-item-action">KI-Blog</a>
-      </div>
-    </div>
-  </div>
-
-  <!-- Mobile Bottom Navigation (<=992px) -->
-  <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../../#workshop">
-      <i class="fas fa-chalkboard-user"></i>
-      <span>Workshop</span>
-    </a>
-    <a class="bottom-nav-item" href="../../wiki/">
-      <i class="fas fa-book"></i>
-      <span>Wiki</span>
-    </a>
-    <button class="bottom-nav-item" data-bs-toggle="offcanvas" data-bs-target="#projekteSheet">
-      <i class="fas fa-rocket"></i>
-      <span>Projekte</span>
-    </button>
-    <a class="bottom-nav-item" href="../../ueber-mich/">
-      <i class="fas fa-user"></i>
-      <span>Coach</span>
-    </a>
-  </nav>
+  <nav id="site-nav"></nav>
 
   <div id="game"></div>
   <script>

--- a/apps/pong/index.html
+++ b/apps/pong/index.html
@@ -25,7 +25,7 @@
   <link rel="stylesheet" href="../../css/footer.css">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: system-ui, sans-serif; background: #111; display: flex; flex-direction: column; justify-content: center; align-items: center; min-height: 100vh; padding-top: 48px; }
+    body { font-family: system-ui, sans-serif; background: #111; display: flex; flex-direction: column; justify-content: center; align-items: center; min-height: 100vh; }
 
     #game { width: 420px; height: 500px; position: relative; }
     .pong-wrap { display:flex; flex-direction:column; align-items:center; height:100%; background:#111; padding:8px; box-sizing:border-box; }
@@ -39,79 +39,7 @@
   </style>
 </head>
 <body>
-  <!-- Desktop Navbar (>992px) -->
-  <nav class="navbar navbar-expand d-none d-lg-flex">
-    <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
-      <a class="navbar-brand" href="../../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
-      </a>
-      <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../../#workshop">Workshop</a>
-        <a class="navbar-link" href="../../wiki/">Wiki</a>
-        <div class="dropdown">
-          <a class="navbar-link dropdown-toggle active" href="../../projekte/" role="button" data-bs-toggle="dropdown" aria-expanded="false">Projekte</a>
-          <ul class="dropdown-menu">
-            <li><a class="dropdown-item active" href="../../apps/pong/">Pong</a></li>
-            <li><a class="dropdown-item" href="../../apps/gta/">Grand Thomas Auto 6</a></li>
-            <li><a class="dropdown-item" href="../../apps/wochenendplanung/">Wochenendplanung</a></li>
-            <li><a class="dropdown-item" href="../../apps/blog/">KI-Blog</a></li>
-          </ul>
-        </div>
-        <a class="navbar-link" href="../../ueber-mich/">Coach</a>
-      </div>
-    </div>
-  </nav>
-
-  <!-- Mobile Top Bar (<=992px) -->
-  <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
-    <a class="mobile-topbar-brand" href="../../">
-      <i class="fas fa-code me-1"></i> Vibecoding Academy
-    </a>
-    <span style="width: 32px;"></span>
-  </div>
-
-  <!-- Mobile Offcanvas: Projekte -->
-  <div class="offcanvas offcanvas-bottom nav-sheet" tabindex="-1" id="projekteSheet" style="height: auto; max-height: 70vh;">
-    <div class="offcanvas-header">
-      <h5 class="offcanvas-title"><i class="fas fa-rocket me-2"></i>Projekte</h5>
-      <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas"></button>
-    </div>
-    <div class="offcanvas-body p-0">
-      <div class="list-group list-group-flush">
-        <a href="../../apps/pong/" class="list-group-item list-group-item-action active">Pong</a>
-        <a href="../../apps/gta/" class="list-group-item list-group-item-action">Grand Thomas Auto 6</a>
-        <a href="../../apps/wochenendplanung/" class="list-group-item list-group-item-action">Wochenendplanung</a>
-        <a href="../../apps/blog/" class="list-group-item list-group-item-action">KI-Blog</a>
-      </div>
-    </div>
-  </div>
-
-  <!-- Mobile Bottom Navigation (<=992px) -->
-  <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../../#workshop">
-      <i class="fas fa-chalkboard-user"></i>
-      <span>Workshop</span>
-    </a>
-    <a class="bottom-nav-item" href="../../wiki/">
-      <i class="fas fa-book"></i>
-      <span>Wiki</span>
-    </a>
-    <button class="bottom-nav-item" data-bs-toggle="offcanvas" data-bs-target="#projekteSheet">
-      <i class="fas fa-rocket"></i>
-      <span>Projekte</span>
-    </button>
-    <a class="bottom-nav-item" href="../../ueber-mich/">
-      <i class="fas fa-user"></i>
-      <span>Coach</span>
-    </a>
-  </nav>
+  <nav id="site-nav"></nav>
   <div id="game"></div>
   <script>
 (function() {

--- a/apps/wochenendplanung/index.html
+++ b/apps/wochenendplanung/index.html
@@ -27,7 +27,6 @@
   <style>
     body {
       background: var(--bg-page);
-      padding-top: 48px;
     }
 
     /* ── Page Header ────────────────────────────────── */
@@ -141,79 +140,7 @@
 </head>
 <body>
 
-  <!-- Desktop Navbar (>992px) -->
-  <nav class="navbar navbar-expand d-none d-lg-flex">
-    <div class="container-fluid">
-      <a href="https://fauteck.github.io/website/" class="navbar-back-link" aria-label="Zurück zu niklasfauteck.de">
-        <i class="fas fa-house me-1"></i> niklasfauteck.de
-      </a>
-      <span class="navbar-back-separator">|</span>
-      <a class="navbar-brand" href="../../">
-        <i class="fas fa-code me-1"></i> Vibecoding Academy
-      </a>
-      <div class="d-flex align-items-center gap-1">
-        <a class="navbar-link" href="../../#workshop">Workshop</a>
-        <a class="navbar-link" href="../../wiki/">Wiki</a>
-        <div class="dropdown">
-          <a class="navbar-link dropdown-toggle active" href="../../projekte/" role="button" data-bs-toggle="dropdown" aria-expanded="false">Projekte</a>
-          <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="../../apps/pong/">Pong</a></li>
-            <li><a class="dropdown-item" href="../../apps/gta/">Grand Thomas Auto 6</a></li>
-            <li><a class="dropdown-item active" href="../../apps/wochenendplanung/">Wochenendplanung</a></li>
-            <li><a class="dropdown-item" href="../../apps/blog/">KI-Blog</a></li>
-          </ul>
-        </div>
-        <a class="navbar-link" href="../../ueber-mich/">Coach</a>
-      </div>
-    </div>
-  </nav>
-
-  <!-- Mobile Top Bar (<=992px) -->
-  <div class="mobile-topbar d-lg-none">
-    <a href="https://fauteck.github.io/website/" class="mobile-topbar-btn" aria-label="Zurück zu niklasfauteck.de">
-      <i class="fas fa-arrow-left"></i>
-    </a>
-    <a class="mobile-topbar-brand" href="../../">
-      <i class="fas fa-code me-1"></i> Vibecoding Academy
-    </a>
-    <span style="width: 32px;"></span>
-  </div>
-
-  <!-- Mobile Offcanvas: Projekte -->
-  <div class="offcanvas offcanvas-bottom nav-sheet" tabindex="-1" id="projekteSheet" style="height: auto; max-height: 70vh;">
-    <div class="offcanvas-header">
-      <h5 class="offcanvas-title"><i class="fas fa-rocket me-2"></i>Projekte</h5>
-      <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas"></button>
-    </div>
-    <div class="offcanvas-body p-0">
-      <div class="list-group list-group-flush">
-        <a href="../../apps/pong/" class="list-group-item list-group-item-action">Pong</a>
-        <a href="../../apps/gta/" class="list-group-item list-group-item-action">Grand Thomas Auto 6</a>
-        <a href="../../apps/wochenendplanung/" class="list-group-item list-group-item-action active">Wochenendplanung</a>
-        <a href="../../apps/blog/" class="list-group-item list-group-item-action">KI-Blog</a>
-      </div>
-    </div>
-  </div>
-
-  <!-- Mobile Bottom Navigation (<=992px) -->
-  <nav class="bottom-nav d-lg-none">
-    <a class="bottom-nav-item" href="../../#workshop">
-      <i class="fas fa-chalkboard-user"></i>
-      <span>Workshop</span>
-    </a>
-    <a class="bottom-nav-item" href="../../wiki/">
-      <i class="fas fa-book"></i>
-      <span>Wiki</span>
-    </a>
-    <button class="bottom-nav-item" data-bs-toggle="offcanvas" data-bs-target="#projekteSheet">
-      <i class="fas fa-rocket"></i>
-      <span>Projekte</span>
-    </button>
-    <a class="bottom-nav-item" href="../../ueber-mich/">
-      <i class="fas fa-user"></i>
-      <span>Coach</span>
-    </a>
-  </nav>
+  <nav id="site-nav"></nav>
 
   <!-- ══════════════════════════════════════════════════ -->
   <!--  Page Header                                      -->


### PR DESCRIPTION
These three apps shipped their own Bootstrap-based navbar markup (.navbar, .mobile-topbar, .bottom-nav, offcanvas) instead of the shared <nav id="site-nav"> placeholder rendered by js/components.js. The custom classes were never styled in nav.css, so the nav rendered as unstyled inline content (visible mixed in with the game canvas in the previous screenshots) and the global footer was injected next to it as a sibling flex item.

Replace the custom markup with the standard global nav placeholder, drop the now-redundant 48px top padding (nav.css already adds the correct 4.5rem), and update GTA's full-viewport game height to match.